### PR TITLE
whitelist: Fix occasional overflow in unit test

### DIFF
--- a/src/zkp/whitelist.rs
+++ b/src/zkp/whitelist.rs
@@ -404,7 +404,7 @@ mod tests {
             // incorrectly serialized with byte changed
             let mut encoded = correct_signature.serialize();
             let len = encoded.len();
-            encoded[len - 1] = (encoded[len - 1] + 1) % 255;
+            encoded[len - 1] = encoded[len - 1] ^ 0x01;
             let decoded = WhitelistSignature::from_slice(&encoded).unwrap();
             assert_eq!(
                 Err(Error::InvalidWhitelistProof),


### PR DESCRIPTION
We bumped into this in master and will happen once every 255 runs on average: https://github.com/ElementsProject/rust-secp256k1-zkp/runs/3951901266?check_suite_focus=true

Just me forgetting that Rust is typed :|