### PR TITLE
Update version of rust-secp dependency to 0.20.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ use-serde = ["serde", "secp256k1/serde"]
 use-rand = ["rand", "secp256k1/rand"]
 
 [dependencies]
-secp256k1 = "0.20.0"
+secp256k1 = "0.20.3"
 secp256k1-zkp-sys = { version = "0.4.0", default-features = false, path = "./secp256k1-zkp-sys" }
 rand = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }


### PR DESCRIPTION
I need some functionalities that were added in rust-secp256k1 0.20.2. Not sure what's the process for upgrading the dependency version so sorry if doing a PR was not the correct way.