### PR TITLE
Backport rust-secp 284 and 422

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,10 +6,6 @@ jobs:
   Nightly:
     name: Nightly - ASan + Bench
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
@@ -17,7 +13,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: nightly
           override: true
           components: rust-src
       - name: Running address sanitizer

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  bench_nightly:
+  Nightly:
     name: Nightly - ASan + Bench
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
+      - name: Install clang for ASan
+        run: sudo apt-get install -y clang
       - name: Checkout Toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,43 +31,6 @@ jobs:
           DO_DOCS: true
         run: ./contrib/test.sh
 
-  # wasm:
-  #   name: Stable - Docs / WebAssembly Build
-  #   strategy:
-  #     matrix:
-  #       target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
-  #       include:
-  #         - target: x86_64-unknown-linux-gnu
-  #           os: ubuntu-latest
-  #           cc: clang-12
-  #           ar: ar
-  #         - target: x86_64-apple-darwin
-  #           os: macos-latest
-  #           cc: /usr/local/opt/llvm/bin/clang
-  #           ar: /usr/local/opt/llvm/bin/llvm-ar
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - name: Checkout Crate
-  #       uses: actions/checkout@v2
-  #     - name: Checkout Toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
-  #     - name: Building docs
-  #       env:
-  #         DO_DOCS: true
-  #       run: ./contrib/test.sh
-  #     - name: Install wasm-pack
-  #       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-  #     - name: Running WASM build
-  #       env:
-  #         DO_WASM: true
-  #         CC: ${{ matrix.cc }}
-  #         AR: ${{ matrix.ar }}
-  #       run: ./contrib/test.sh
-
   Tests:
     name: Tests
     strategy:
@@ -98,6 +61,29 @@ jobs:
       - name: Running cargo
         env:
           DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  WASM:
+    name: WASM
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable, beta, nightly] # No 1.29 because WASM requires Rust 1.30
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Install clang
+        run: sudo apt-get install -y clang-9
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rust-src
+      - name: Running WASM tests
+        env:
+          DO_WASM: true
         run: ./contrib/test.sh
 
   ReleaseTests:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ name: Continuous integration
 
 jobs:
   Nightly:
-    name: Nightly - ASan + Bench
+    name: Nightly - ASan + Bench + Docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Crate
@@ -25,6 +25,10 @@ jobs:
       - name: Running benchmarks
         env:
           DO_BENCH: true
+        run: ./contrib/test.sh
+      - name: Building docs
+        env:
+          DO_DOCS: true
         run: ./contrib/test.sh
 
   # wasm:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rust-src
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Running WASM tests
         env:
           DO_WASM: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout Crate
         uses: actions/checkout@v2
       - name: Install clang
-        run: sudo apt-get install -y clang-9
+        run: sudo apt-get install -y clang
       - name: Checkout Toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ serde_test = "1.0"
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"
 rand = { version = "0.8" }
+getrandom = { version = "0.2", features = ["js"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -79,3 +79,5 @@ then
         cargo fmt --all -- --check
     )
 fi
+
+exit 0

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -59,6 +59,7 @@ fi
 
 # Address Sanitizer
 if [ "$DO_ASAN" = true ]; then
+    clang --version
     cargo clean
     CC='clang -fsanitize=address -fno-omit-frame-pointer'                                        \
     RUSTFLAGS='-Zsanitizer=address -Clinker=clang -Cforce-frame-pointers=yes'                    \

--- a/secp256k1-zkp-sys/build.rs
+++ b/secp256k1-zkp-sys/build.rs
@@ -63,11 +63,9 @@ fn main() {
         }
     }
 
-    match &env::var("TARGET").unwrap() as &str {
-        "wasm32-unknown-unknown" | "wasm32-wasi" => {
-            base_config.include("wasm-sysroot");
-        }
-        _ => {}
+    // Header files. WASM only.
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "wasm32" {
+        base_config.include("wasm-sysroot");
     }
 
     // secp256k1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,6 @@
 //!
 
 // Coding conventions
-#![deny(non_upper_case_globals)]
-#![deny(non_camel_case_types)]
-#![deny(non_snake_case)]
-#![deny(unused_mut)]
 #![warn(missing_docs)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
@@ -47,10 +43,13 @@ extern crate secp256k1;
 pub use secp256k1::hashes;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
+/// Re-export rand
 #[cfg(any(test, feature = "rand"))]
 pub extern crate rand;
+/// Re-export rand_core
 #[cfg(test)]
 extern crate rand_core;
+/// Re-export serde
 #[cfg(feature = "serde")]
 pub extern crate serde;
 #[cfg(all(test, feature = "serde"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 
-#[macro_use]
+/// Re-export secp256k1_zkp_sys
 pub extern crate secp256k1_zkp_sys;
 pub use secp256k1_zkp_sys as ffi;
 
@@ -49,7 +49,7 @@ pub use secp256k1::hashes;
 extern crate core;
 #[cfg(any(test, feature = "rand"))]
 pub extern crate rand;
-#[cfg(any(test))]
+#[cfg(test)]
 extern crate rand_core;
 #[cfg(feature = "serde")]
 pub extern crate serde;

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 #[derive(Default, Copy, Clone)]
 #[cfg_attr(not(fuzzing), derive(Eq, PartialEq))]
 pub struct Tweak([u8; constants::SECRET_KEY_SIZE]);
-impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
+secp256k1_zkp_sys::impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
 
 /// The zero Tweak
 pub const ZERO_TWEAK: Tweak = Tweak([
@@ -21,7 +21,7 @@ pub const ZERO_TWEAK: Tweak = Tweak([
 impl fmt::Debug for Tweak {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Tweak(")?;
-        for i in self[..].iter().cloned() {
+        for i in self[..].iter() {
             write!(f, "{:02x}", i)?;
         }
         write!(f, ")")

--- a/src/zkp/rangeproof.rs
+++ b/src/zkp/rangeproof.rs
@@ -65,6 +65,7 @@ impl RangeProof {
     }
 
     /// Prove that `commitment` hides a value within a range, with the lower bound set to `min_value`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new<C: Signing>(
         secp: &Secp256k1<C>,
         min_value: u64,

--- a/src/zkp/surjection_proof.rs
+++ b/src/zkp/surjection_proof.rs
@@ -143,6 +143,7 @@ impl SurjectionProof {
     }
 
     /// Find the length of surjection proof when serialized
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         unsafe {
             ffi::secp256k1_surjectionproof_serialized_size(

--- a/src/zkp/whitelist.rs
+++ b/src/zkp/whitelist.rs
@@ -339,7 +339,7 @@ mod tests {
             // wrong n_keys
             let sig = unsafe {
                 let sig = correct_signature.clone();
-                let mut ptr = sig.as_c_ptr() as *mut ffi::WhitelistSignature;
+                let ptr = sig.as_c_ptr() as *mut ffi::WhitelistSignature;
                 (*ptr).n_keys -= 1;
                 sig
             };

--- a/src/zkp/whitelist.rs
+++ b/src/zkp/whitelist.rs
@@ -18,7 +18,7 @@ pub struct WhitelistSignature(ffi::WhitelistSignature);
 impl WhitelistSignature {
     /// Number of keys in the whitelist.
     pub fn n_keys(&self) -> usize {
-        self.0.n_keys as usize
+        self.0.n_keys
     }
 
     /// Serialize to bytes.


### PR DESCRIPTION
Fixes #47

(Actually I believe 47 is already fixed, but this re-enables the test in CI so we can be sure.)

Easiest way to review this is probably to add rust-secp as a remote and then use `range-diff` to see how my versions of the commits change from those in the PR. I have provided commit IDs in my commit messages.