### PR TITLE
nits from `cargo test` and `cargo clippy` on latest nightly

### DIFF
--- a/secp256k1-zkp-sys/src/zkp.rs
+++ b/secp256k1-zkp-sys/src/zkp.rs
@@ -426,6 +426,12 @@ impl PartialEq for SurjectionProof {
 
 impl Eq for SurjectionProof {}
 
+impl Default for SurjectionProof {
+    fn default() -> Self {
+        SurjectionProof::new()
+    }
+}
+
 impl hash::Hash for SurjectionProof {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.n_inputs.hash(state);
@@ -527,7 +533,7 @@ impl Default for PedersenCommitment {
 #[cfg(not(fuzzing))]
 impl PartialEq for PedersenCommitment {
     fn eq(&self, other: &Self) -> bool {
-        &self.0[..] == &other.0[..]
+        self.0[..] == other.0[..]
     }
 }
 
@@ -594,6 +600,12 @@ pub struct EcdsaAdaptorSignature([u8; ECDSA_ADAPTOR_SIGNATURE_LENGTH]);
 impl_array_newtype!(EcdsaAdaptorSignature, u8, ECDSA_ADAPTOR_SIGNATURE_LENGTH);
 impl_raw_debug!(EcdsaAdaptorSignature);
 
+impl Default for EcdsaAdaptorSignature {
+    fn default() -> EcdsaAdaptorSignature {
+        EcdsaAdaptorSignature::new()
+    }
+}
+
 impl EcdsaAdaptorSignature {
     /// Create a new (zeroed) ecdsa adaptor signature usable for the FFI interface
     pub fn new() -> Self {
@@ -617,7 +629,7 @@ impl EcdsaAdaptorSignature {
 #[cfg(not(fuzzing))]
 impl PartialEq for EcdsaAdaptorSignature {
     fn eq(&self, other: &Self) -> bool {
-        &self.0[..] == &other.0[..]
+        self.0[..] == other.0[..]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,9 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 
-/// Re-export secp256k1_zkp_sys
+/// Re-export of the internal FFI bindings crate
 pub extern crate secp256k1_zkp_sys;
+/// Re-export of the internal FFI bindings crate under the alternate name `ffi`
 pub use secp256k1_zkp_sys as ffi;
 
 extern crate secp256k1;
@@ -43,13 +44,12 @@ extern crate secp256k1;
 pub use secp256k1::hashes;
 #[cfg(any(test, feature = "std"))]
 extern crate core;
-/// Re-export rand
+/// Re-export of the `rand` crate
 #[cfg(any(test, feature = "rand"))]
 pub extern crate rand;
-/// Re-export rand_core
 #[cfg(test)]
 extern crate rand_core;
-/// Re-export serde
+/// Re-export of the `serde` crate
 #[cfg(feature = "serde")]
 pub extern crate serde;
 #[cfg(all(test, feature = "serde"))]

--- a/src/zkp/surjection_proof.rs
+++ b/src/zkp/surjection_proof.rs
@@ -153,6 +153,14 @@ impl SurjectionProof {
         }
     }
 
+    /// Whether the proof has zero length
+    ///
+    /// Always returns `false` since a surjection proof must contain at least
+    /// one 32-byte hash.
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
     /// Verify a surjection proof.
     #[must_use]
     pub fn verify<C: Verification>(


### PR DESCRIPTION
The newest nightly has a new "unused mut" warning which is causing CI to fail. Fix that, and while we're at it, run clippy. And while we're at that, remove some `#[deny]` conditions from the crate root since these properly belong in CI (via -D warnings) rather than in the source.