### PR TITLE
Impl PartialOrd, Ord for 3 types

### DIFF
--- a/secp256k1-zkp-sys/src/zkp.rs
+++ b/secp256k1-zkp-sys/src/zkp.rs
@@ -426,6 +426,26 @@ impl PartialEq for SurjectionProof {
 
 impl Eq for SurjectionProof {}
 
+impl Ord for SurjectionProof {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        match self.n_inputs.cmp(&other.n_inputs) {
+            core::cmp::Ordering::Equal => {}
+            ord => return ord,
+        }
+        match self.used_inputs.cmp(&other.used_inputs) {
+            core::cmp::Ordering::Equal => {}
+            ord => return ord,
+        }
+        self.data.cmp(&other.data)
+    }
+}
+
+impl PartialOrd for SurjectionProof {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl Default for SurjectionProof {
     fn default() -> Self {
         SurjectionProof::new()
@@ -454,7 +474,7 @@ impl SurjectionProof {
 
 #[cfg(feature = "std")]
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RangeProof(Box<[c_uchar]>);
 
 #[cfg(feature = "std")]
@@ -514,6 +534,8 @@ impl From<Tag> for [u8; 32] {
 // TODO: Replace this with ffi::PublicKey?
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[cfg_attr(not(fuzzing), derive(Ord, PartialOrd))]
+
 pub struct PedersenCommitment([c_uchar; 64]);
 impl_array_newtype!(PedersenCommitment, c_uchar, 64);
 impl_raw_debug!(PedersenCommitment);

--- a/src/zkp/pedersen.rs
+++ b/src/zkp/pedersen.rs
@@ -5,7 +5,7 @@ use crate::{from_hex, Error, Generator, Secp256k1, Signing, Tweak, ZERO_TWEAK};
 use core::{fmt, slice, str};
 
 /// Represents a commitment to a single u64 value.
-#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Hash, PartialOrd, Ord)]
 pub struct PedersenCommitment(ffi::PedersenCommitment);
 
 impl PedersenCommitment {

--- a/src/zkp/rangeproof.rs
+++ b/src/zkp/rangeproof.rs
@@ -13,7 +13,7 @@ use std::str;
 /// Represents a range proof.
 ///
 /// TODO: Store rangeproof info
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, PartialOrd, Ord)]
 pub struct RangeProof {
     inner: ffi::RangeProof,
 }

--- a/src/zkp/surjection_proof.rs
+++ b/src/zkp/surjection_proof.rs
@@ -6,7 +6,7 @@ use core::mem::size_of;
 use std::str;
 
 /// Represents a surjection proof.
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, PartialOrd, Ord)]
 pub struct SurjectionProof {
     inner: ffi::SurjectionProof,
 }


### PR DESCRIPTION
RangeProof, SurjectionProof and PedersenCommitment

The purpose of this is having downstream types like elements::Transaction be usable in ordered collections.

bitcoin::Transaction already support this for the same reason