### PR TITLE
secp256k1-zkp-sys: remove not(fuzzing) gates on derives

### DIFF
--- a/secp256k1-zkp-sys/CHANGELOG.md
+++ b/secp256k1-zkp-sys/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.1 - 2023-01-03
+
+- Many changes; restart CHANGELOG.
+
 # 0.2.0 - 2021-01-06
 
 - Completely replaced with https://github.com/comit-network/rust-secp256k1-zkp/ which has

--- a/secp256k1-zkp-sys/Cargo.toml
+++ b/secp256k1-zkp-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-zkp-sys"
-version = "0.9.0"
+version = "0.9.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>",

--- a/secp256k1-zkp-sys/src/zkp.rs
+++ b/secp256k1-zkp-sys/src/zkp.rs
@@ -501,8 +501,7 @@ impl RangeProof {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[cfg_attr(not(fuzzing), derive(Eq, PartialEq, Hash, Ord, PartialOrd))]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Tag([c_uchar; 32]);
 impl_array_newtype!(Tag, c_uchar, 32);
 impl_raw_debug!(Tag);
@@ -533,8 +532,7 @@ impl From<Tag> for [u8; 32] {
 
 // TODO: Replace this with ffi::PublicKey?
 #[repr(C)]
-#[derive(Copy, Clone)]
-#[cfg_attr(not(fuzzing), derive(Ord, PartialOrd))]
+#[derive(Copy, Clone, Ord, PartialOrd)]
 pub struct PedersenCommitment([c_uchar; 64]);
 impl_array_newtype!(PedersenCommitment, c_uchar, 64);
 impl_raw_debug!(PedersenCommitment);
@@ -551,17 +549,14 @@ impl Default for PedersenCommitment {
     }
 }
 
-#[cfg(not(fuzzing))]
 impl PartialEq for PedersenCommitment {
     fn eq(&self, other: &Self) -> bool {
         self.0[..] == other.0[..]
     }
 }
 
-#[cfg(not(fuzzing))]
 impl Eq for PedersenCommitment {}
 
-#[cfg(not(fuzzing))]
 impl Hash for PedersenCommitment {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
@@ -647,12 +642,10 @@ impl EcdsaAdaptorSignature {
     }
 }
 
-#[cfg(not(fuzzing))]
 impl PartialEq for EcdsaAdaptorSignature {
     fn eq(&self, other: &Self) -> bool {
         self.0[..] == other.0[..]
     }
 }
 
-#[cfg(not(fuzzing))]
 impl Eq for EcdsaAdaptorSignature {}

--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -8,8 +8,7 @@ use rand::Rng;
 ///
 /// Contrary to a [`crate::SecretKey`], the value 0 is also a valid tweak.
 /// Values outside secp curve order are invalid tweaks.
-#[derive(Default, Copy, Clone)]
-#[cfg_attr(not(fuzzing), derive(Eq, PartialEq, PartialOrd, Ord, Hash))]
+#[derive(Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Tweak([u8; constants::SECRET_KEY_SIZE]);
 secp256k1_zkp_sys::impl_array_newtype!(Tweak, u8, constants::SECRET_KEY_SIZE);
 


### PR DESCRIPTION
I'm not sure why these derives are gated on not(fuzzing); I believe that there used to be fuzzing-only manual implementations. These do not exist anymore (or maybe they only existed upstream), and as a result the library does not compile when fuzzing is enabled.

Also, make sure that cfg(fuzzing) is replaced by cfg(rust_secp_fuzz) everywhere so that the user has the ability to disable fuzzing mode.