### PR TITLE
release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1 - 2024-01-10
+
+- Fix compilation when `cfg(fuzzing)` is set
+
 # 0.10.0 - 2024-01-02
 
 - update `secp256k1` to 0.28.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-zkp"
-version = "0.10.0"
+version = "0.10.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Lucas Soriano <lucas@comit.network>",


### PR DESCRIPTION
This is a point release which just impls some traits when `cfg(fuzzing)` is set and does no other changes.