### PR TITLE
README: fix MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Contributions to this library are welcome. A few guidelines:
 - Any breaking changes must have an accompanied entry in CHANGELOG.md
 - No new dependencies, please.
 - No crypto should be implemented in Rust, with the possible exception of hash functions. Cryptographic contributions should be directed upstream to libsecp256k1.
-- This library should always compile with any combination of features on **Rust 1.41.1**.
+- This library should always compile with any combination of features on **Rust 1.56.1**.
 


### PR DESCRIPTION
MSRV was increased in a previous commit, but the README was not updated.

Fixes #83.