### PR TITLE
fix: WASM

### DIFF
--- a/secp256k1-zkp-sys/depend/secp256k1/src/util.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/util.h
@@ -19,26 +19,6 @@
 #define DEBUG_CONFIG_MSG(x) "DEBUG_CONFIG: " x
 #define DEBUG_CONFIG_DEF(x) DEBUG_CONFIG_MSG(#x "=" STR(x))
 
-/* Debug helper for printing arrays of unsigned char. */
-#define PRINT_BUF(buf, len) do { \
-    printf("%s[%lu] = ", #buf, (unsigned long)len); \
-    print_buf_plain(buf, len); \
-} while(0)
-
-static void print_buf_plain(const unsigned char *buf, size_t len) {
-    size_t i;
-    printf("{");
-    for (i = 0; i < len; i++) {
-        if (i % 8 == 0) {
-            printf("\n    ");
-        } else {
-            printf(" ");
-        }
-        printf("0x%02X,", buf[i]);
-    }
-    printf("\n}\n");
-}
-
 # if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L) )
 #  if SECP256K1_GNUC_PREREQ(2,7)
 #   define SECP256K1_INLINE __inline__

--- a/secp256k1-zkp-sys/depend/util.h.patch
+++ b/secp256k1-zkp-sys/depend/util.h.patch
@@ -1,8 +1,35 @@
 diff --git a/secp256k1-zkp-sys/depend/secp256k1/src/util.h b/secp256k1-zkp-sys/depend/secp256k1/src/util.h
-index 10ea516..4066d2a 100644
+index 10ea516..2c53866 100644
 --- a/secp256k1-zkp-sys/depend/secp256k1/src/util.h
 +++ b/secp256k1-zkp-sys/depend/secp256k1/src/util.h
-@@ -153,14 +153,6 @@ static const secp256k1_callback default_error_callback = {
+@@ -19,26 +19,6 @@
+ #define DEBUG_CONFIG_MSG(x) "DEBUG_CONFIG: " x
+ #define DEBUG_CONFIG_DEF(x) DEBUG_CONFIG_MSG(#x "=" STR(x))
+ 
+-/* Debug helper for printing arrays of unsigned char. */
+-#define PRINT_BUF(buf, len) do { \
+-    printf("%s[%lu] = ", #buf, (unsigned long)len); \
+-    print_buf_plain(buf, len); \
+-} while(0)
+-
+-static void print_buf_plain(const unsigned char *buf, size_t len) {
+-    size_t i;
+-    printf("{");
+-    for (i = 0; i < len; i++) {
+-        if (i % 8 == 0) {
+-            printf("\n    ");
+-        } else {
+-            printf(" ");
+-        }
+-        printf("0x%02X,", buf[i]);
+-    }
+-    printf("\n}\n");
+-}
+-
+ # if (!defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L) )
+ #  if SECP256K1_GNUC_PREREQ(2,7)
+ #   define SECP256K1_INLINE __inline__
+@@ -153,14 +133,6 @@ static const secp256k1_callback default_error_callback = {
  #define VERIFY_CHECK(cond)
  #endif
  


### PR DESCRIPTION
Port of https://github.com/rust-bitcoin/rust-secp256k1/pull/735

Let's see if this passes CI. I can run `cargo build --target wasm32-unknown-unknown` after my commit.

Generating the `.patch` files was kind of hard. Is there an easy way?