### PR TITLE
Release 0.11.1 (fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.11.1 - 2024-10-21
-
-- Fix compilation on target wasm32-unknown-unknown
-
 # 0.11.0 - 2024-07-09
 
 - Update upstream to 6152622613fdf1c5af6f31f74c427c4e9ee120ce

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-zkp"
-version = "0.11.1"
+version = "0.11.0"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Lucas Soriano <lucas@comit.network>",

--- a/secp256k1-zkp-sys/CHANGELOG.md
+++ b/secp256k1-zkp-sys/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1 - 2024-10-24
+
+- Fix compilation on target wasm32-unknown-unknown
+
 # 0.10.0 - 2024-07-09
 
 - Update upstream to 6152622613fdf1c5af6f31f74c427c4e9ee120ce

--- a/secp256k1-zkp-sys/Cargo.toml
+++ b/secp256k1-zkp-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256k1-zkp-sys"
-version = "0.10.0"
+version = "0.10.1"
 authors = [ "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>",
             "Steven Roose <steven@stevenroose.org>",


### PR DESCRIPTION
Update the sys crate and revert the update of the parent crate. Fixes #87 