### PR TITLE
 zkp: check input lengths in from_slice before FFI parsing

### DIFF
--- a/src/zkp/generator.rs
+++ b/src/zkp/generator.rs
@@ -132,6 +132,12 @@ impl Generator {
 
     /// Parse a generator from a slice of bytes.
     pub fn from_slice(bytes: &[u8]) -> Result<Self, Error> {
+        // The FFI parser takes no length and unconditionally reads 33 bytes
+        // from the slice pointer; reject other lengths here to avoid an
+        // out-of-bounds read (a segfault on empty input).
+        if bytes.len() != 33 {
+            return Err(Error::InvalidGenerator);
+        }
         let mut public_key = unsafe { ffi::PublicKey::new() };
 
         let ret = unsafe {
@@ -266,5 +272,20 @@ impl<'de> ::serde::Deserialize<'de> for Tweak {
 
 #[cfg(test)]
 mod tests {
+    use super::Generator;
+
     // TODO: Test prefix of serialization
+
+    #[test]
+    fn from_slice_rejects_bad_lengths() {
+        // The FFI parser takes no length and unconditionally reads 33 bytes
+        // from the slice pointer; empty and short slices must be rejected
+        // before reaching FFI (an empty slice segfaults on address 0x1).
+        for len in [0usize, 1, 32] {
+            let bytes = vec![0u8; len];
+            assert!(Generator::from_slice(&bytes).is_err());
+        }
+        // A 33-byte input reaches FFI and is rejected on content, not by crash.
+        assert!(Generator::from_slice(&[0u8; 33]).is_err());
+    }
 }

--- a/src/zkp/pedersen.rs
+++ b/src/zkp/pedersen.rs
@@ -29,6 +29,12 @@ impl PedersenCommitment {
 
     /// Parse a pedersen commitment from a byte slice.
     pub fn from_slice(bytes: &[u8]) -> Result<Self, Error> {
+        // The FFI parser takes no length and unconditionally reads 33 bytes
+        // from the slice pointer; reject other lengths here to avoid an
+        // out-of-bounds read (a segfault on empty input).
+        if bytes.len() != 33 {
+            return Err(Error::InvalidPedersenCommitment);
+        }
         let mut commitment = ffi::PedersenCommitment::default();
 
         let ret = unsafe {
@@ -292,6 +298,19 @@ mod tests {
         let got = PedersenCommitment::from_slice(&bytes).unwrap();
 
         assert_eq!(got, commitment);
+    }
+
+    #[test]
+    fn from_slice_rejects_bad_lengths() {
+        // The FFI parser takes no length and unconditionally reads 33 bytes
+        // from the slice pointer; empty and short slices must be rejected
+        // before reaching FFI (an empty slice segfaults on address 0x1).
+        for len in [0usize, 1, 32] {
+            let bytes = vec![0u8; len];
+            assert!(PedersenCommitment::from_slice(&bytes).is_err());
+        }
+        // A 33-byte input reaches FFI and is rejected on content, not by crash.
+        assert!(PedersenCommitment::from_slice(&[0u8; 33]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
`PedersenCommitment::from_slice` and `Generator::from_slice` are safe functions wrapping FFI parsers (`secp256k1_pedersen_commitment_parse`, `secp256k1_generator_parse`) that take no length argument and unconditionally read 33 bytes from the slice pointer. Passing an empty or short slice is therefore an out-of-bounds read; on an empty slice the dangling pointer (address 0x1) is dereferenced and the process segfaults instead of returning an error.

This makes the safe `from_slice` API unsound for any caller parsing untrusted input. A concrete downstream instance: rust-elements deserializes PSET commitment fields (`issuance_value_comm`, `issuance_inflation_keys_comm`, `amount_comm`, `asset_comm`) through these functions, so a malicious PSET segfaults any application parsing it. Found by libFuzzer/AddressSanitizer on the rust-elements `deserialize_pset` target; the rust-elements side is fixed in a separate PR.

Reject any length other than 33 bytes before reaching FFI. The C parsers have no length parameter and read exactly one prefix byte plus a 32-byte x coordinate, so 33 is the only valid input size; the guard restricts no legitimate use. Adds regression tests for empty, short and invalid-content inputs.

The other FFI parse entry points were audited and are not affected: `surjectionproof_parse`, `whitelist_signature_parse` and `rangeproof_info` all validate the input length before dereferencing.

related to https://github.com/BlockstreamResearch/rust-secp256k1-zkp/pull/101