### PR TITLE
chore: re-vendor secp256k1-zkp to 10366db

### DIFF
--- a/secp256k1-zkp-sys/depend/secp256k1-HEAD-revision.txt
+++ b/secp256k1-zkp-sys/depend/secp256k1-HEAD-revision.txt
@@ -1,2 +1,2 @@
 # This file was automatically created by vendor-libsecp.sh
-95b983597af0e5762a1266ede302806883045d22
+10366dbbbfeb11457f2aae3b23e154ab7d6a1fe4

--- a/secp256k1-zkp-sys/depend/secp256k1/.github/actions/install-homebrew-valgrind/action.yml
+++ b/secp256k1-zkp-sys/depend/secp256k1/.github/actions/install-homebrew-valgrind/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     - run: |
         brew tap LouisBrunner/valgrind
+        brew trust --formula LouisBrunner/valgrind/valgrind
         brew fetch --HEAD LouisBrunner/valgrind/valgrind
         echo "CI_HOMEBREW_CELLAR_VALGRIND=$(brew --cellar valgrind)" >> "$GITHUB_ENV"
       shell: bash

--- a/secp256k1-zkp-sys/depend/secp256k1/README.md
+++ b/secp256k1-zkp-sys/depend/secp256k1/README.md
@@ -37,20 +37,21 @@ This can be done with the following steps:
     ```
 4. Check out the latest release tag, e.g. 
     ```
-    git checkout v0.6.0
+    git checkout v0.7.1
     ```
 5. Use git to verify the GPG signature: 
    ```
-   % git tag -v v0.6.0 | grep -C 3 'Good signature'
+   % git tag -v v0.7.1 | grep -C 3 'Good signature'
 
-   gpg: Signature made Mon 04 Nov 2024 12:14:44 PM EST
-   gpg:                using RSA key 4BBB845A6F5A65A69DFAEC234861DBF262123605
-   gpg: Good signature from "Jonas Nick <jonas@n-ck.net>" [unknown]
-   gpg:                 aka "Jonas Nick <jonasd.nick@gmail.com>" [unknown]
+   gpg: Signature made Mon 26 Jan 2026 07:42:46 PM UTC
+   gpg:                using RSA key 2840EAABF4BC9F0FFD716AFAFBAFCC46DE2D3FE2
+   gpg: Good signature from "Pieter Wuille <pieter@wuille.net>" [unknown]
+   gpg:                 aka "Pieter Wuille <pieter.wuille@gmail.com>" [full]
+   gpg:                 aka "[jpeg image of size 5996]" [undefined]
    gpg: WARNING: This key is not certified with a trusted signature!
    gpg:          There is no indication that the signature belongs to the owner.
-   Primary key fingerprint: 36C7 1A37 C9D9 88BD E825  08D9 B1A7 0E4F 8DCD 0366
-        Subkey fingerprint: 4BBB 845A 6F5A 65A6 9DFA  EC23 4861 DBF2 6212 3605
+   Primary key fingerprint: 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320
+        Subkey fingerprint: 2840 EAAB F4BC 9F0F FD71  6AFA FBAF CC46 DE2D 3FE2
    ```
 
 Building with Autotools

--- a/secp256k1-zkp-sys/depend/secp256k1/SECURITY.md
+++ b/secp256k1-zkp-sys/depend/secp256k1/SECURITY.md
@@ -9,7 +9,6 @@ The following keys may be used to communicate sensitive information to developer
 | Name | Fingerprint |
 |------|-------------|
 | Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
-| Jonas Nick | 36C7 1A37 C9D9 88BD E825  08D9 B1A7 0E4F 8DCD 0366 |
 | Tim Ruffing | 09E0 3F87 1092 E40E 106E  902B 33BC 86AB 80FF 5516 |
 
 You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.

--- a/secp256k1-zkp-sys/depend/secp256k1/cmake/SetLibtoolAbiVersion.cmake
+++ b/secp256k1-zkp-sys/depend/secp256k1/cmake/SetLibtoolAbiVersion.cmake
@@ -1,0 +1,61 @@
+#[=[
+This emulates Libtool to make sure Libtool and CMake agree on
+the ABI version and file naming for shared libraries.
+
+The `version_type` variable is set in `libtool.m4` (installed
+by autoreconf into autotools-aux/m4/).
+For the `major` and `versuffix` variables, see below "Calculate
+the version variables" in `ltmain.sh` (installed by autoreconf
+into autotools-aux/).
+]=]
+function(set_libtool_abi_version target current revision age)
+  if(CMAKE_SYSTEM_NAME MATCHES "^(Linux|FreeBSD)$")
+    # version_type = linux | freebsd-elf
+    # major = $current - $age
+    # versuffix = $major.$age.$revision
+    math(EXPR _major "${current} - ${age}")
+    set_target_properties(${target} PROPERTIES
+      SOVERSION ${_major}
+      VERSION ${_major}.${age}.${revision}
+    )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
+    # version_type = sunos
+    # major = $current
+    # versuffix = $current.$revision
+    set_target_properties(${target} PROPERTIES
+      SOVERSION ${current}
+      VERSION ${current}.${revision}
+    )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    # version_type = sunos
+    # major = $current
+    # versuffix = $current.$revision
+    set_target_properties(${target} PROPERTIES
+      # OpenBSD has no `soname_spec` defined in `libtool.m4`.
+      VERSION ${current}.${revision}
+    )
+  elseif(APPLE)
+    # version_type = darwin
+    # major = $current - $age
+    math(EXPR _major "${current} - ${age}")
+    math(EXPR _compatibility "${current} + 1")
+    set_target_properties(${target} PROPERTIES
+      SOVERSION ${_major}
+      MACHO_COMPATIBILITY_VERSION ${_compatibility}
+      MACHO_CURRENT_VERSION ${_compatibility}.${revision}
+    )
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # version_type = windows
+    # major = $current - $age
+    # versuffix = $major
+    math(EXPR _major "${current} - ${age}")
+    set(_windows_name "secp256k1")
+    if(MSVC)
+      set(_windows_name "${PROJECT_NAME}")
+    endif()
+    set_target_properties(${target} PROPERTIES
+      ARCHIVE_OUTPUT_NAME "${_windows_name}"
+      RUNTIME_OUTPUT_NAME "${_windows_name}-${_major}"
+    )
+  endif()
+endfunction()

--- a/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1.h
@@ -623,7 +623,7 @@ SECP256K1_API const rustsecp256k1zkp_v0_11_0_nonce_function rustsecp256k1zkp_v0_
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the secret key was invalid.
  *  Args:    ctx:       pointer to a context object (not rustsecp256k1zkp_v0_11_0_context_static).
- *  Out:     sig:       pointer to an array where the signature will be placed.
+ *  Out:     sig:       pointer to a signature object.
  *  In:      msghash32: the 32-byte message hash being signed.
  *           seckey:    pointer to a 32-byte secret key.
  *           noncefp:   pointer to a nonce generation function. If NULL,

--- a/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1_rangeproof.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1_rangeproof.h
@@ -125,7 +125,14 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int rustsecp256k1zkp_v0_11_0_rangepro
  *          commit: the commitment being proved.
  *          blind:  32-byte blinding factor used by commit. The blinding factor may be all-zeros as long as min_bits is set to 3 or greater.
  *                  This is a side-effect of the underlying crypto, not a deliberate API choice, but it may be useful when balancing CT transactions.
- *          nonce:  32-byte secret nonce used to initialize the proof (value can be reverse-engineered out of the proof if this secret is known.)
+ *          nonce:  32-byte secret nonce used to initialize the proof.
+ *
+ *                  Each call to this function must have a UNIQUE nonce that
+ *                  MUST NOT BE REUSED in subsequent calls. The nonce must be
+ *                  KEPT SECRET except from parties authorized to rewind the
+ *                  proof. Anyone who knows the nonce can recover `value` and
+ *                  `blind` from the proof. Reusing the nonce may expose `blind`
+ *                  even to parties that do not know the nonce.
  *          exp:    Base-10 exponent. Digits below above will be made public, but the proof will be made smaller. Allowed range is -1 to 18.
  *                  (-1 is a special case that makes the value public. 0 is the most private.)
  *          min_bits: Number of bits of the value to keep private. (0 = auto/minimal, - 64).

--- a/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1_recovery.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1_recovery.h
@@ -73,7 +73,7 @@ SECP256K1_API int rustsecp256k1zkp_v0_11_0_ecdsa_recoverable_signature_serialize
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the secret key was invalid.
  *  Args:    ctx:       pointer to a context object (not rustsecp256k1zkp_v0_11_0_context_static).
- *  Out:     sig:       pointer to an array where the signature will be placed.
+ *  Out:     sig:       pointer to a signature object.
  *  In:      msghash32: the 32-byte message hash being signed.
  *           seckey:    pointer to a 32-byte secret key.
  *           noncefp:   pointer to a nonce generation function. If NULL,

--- a/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1_whitelist.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/include/secp256k1_whitelist.h
@@ -68,6 +68,10 @@ SECP256K1_API int rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(
  *
  *  Returns: the number of keys for the given signature
  *  In: sig: pointer to a signature object
+ *
+ *  This count is a property of the signature only. It might not match the
+ *  number of public keys the caller has, and the caller should not truncate
+ *  their key set to match it.
  */
 SECP256K1_API size_t rustsecp256k1zkp_v0_11_0_whitelist_signature_n_keys(
     const rustsecp256k1zkp_v0_11_0_whitelist_signature *sig
@@ -109,6 +113,8 @@ SECP256K1_API int rustsecp256k1zkp_v0_11_0_whitelist_signature_serialize(
  *     online_i + H(offline_i + whitelist)(offline_i + whitelist)
  * for each public key pair (offline_i, offline_i). Here H means sha256 of the
  * compressed serialization of the key.
+ *
+ * See rustsecp256k1zkp_v0_11_0_whitelist_verify for the rationale on the degenerate destination W = -P_i.
  */
 SECP256K1_API int rustsecp256k1zkp_v0_11_0_whitelist_sign(
   const rustsecp256k1zkp_v0_11_0_context *ctx,
@@ -131,6 +137,13 @@ SECP256K1_API int rustsecp256k1zkp_v0_11_0_whitelist_sign(
  *         offline_pubkeys: list of all offline pubkeys
  *         n_keys: the number of entries in each of the above two arrays
  *         sub_pubkey: the key to be whitelisted
+ *
+ *  When the destination W equals -P_i for a whitelisted offline key, the tweak
+ *  degenerates and the ring key collapses to K_i = Q_i, so the online key alone
+ *  produces a valid proof for that destination. This is accepted deliberately:
+ *  the output is spendable only by the holder of p_i (the discrete log of -P_i
+ *  is -p_i), i.e. the offline half of the same whitelist entry, so no funds can
+ *  be diverted.
  */
 SECP256K1_API int rustsecp256k1zkp_v0_11_0_whitelist_verify(
   const rustsecp256k1zkp_v0_11_0_context *ctx,

--- a/secp256k1-zkp-sys/depend/secp256k1/src/bench_ecmult.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/bench_ecmult.c
@@ -88,7 +88,7 @@ static void bench_ecmult_teardown_helper(bench_data* data, size_t* seckey_offset
             rustsecp256k1zkp_v0_11_0_scalar_add(&sum_scalars, &sum_scalars, &s);
         }
     }
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&data->ctx->ecmult_gen_ctx, &tmp, &sum_scalars);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&data->ctx->ecmult_gen_ctx, &tmp, &sum_scalars);
     CHECK(rustsecp256k1zkp_v0_11_0_gej_eq_var(&tmp, &sum_output));
 }
 
@@ -104,7 +104,7 @@ static void bench_ecmult_gen(void* arg, int iters) {
     int i;
 
     for (i = 0; i < iters; ++i) {
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&data->ctx->ecmult_gen_ctx, &data->output[i], &data->scalars[(data->offset1+i) % POINTS]);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&data->ctx->ecmult_gen_ctx, &data->output[i], &data->scalars[(data->offset1+i) % POINTS]);
     }
 }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/bench_internal.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/bench_internal.c
@@ -203,6 +203,17 @@ static void bench_field_normalize(void* arg, int iters) {
     }
 }
 
+static void bench_field_normalize_var(void* arg, int iters) {
+    int i;
+    bench_inv *data = (bench_inv*)arg;
+
+    /* Note that this benchmark measures the optimistic path. The worst-case path with the final
+       reduction is very unlikely to be needed, so this is representative of the common case. */
+    for (i = 0; i < iters; i++) {
+        rustsecp256k1zkp_v0_11_0_fe_normalize_var(&data->fe[0]);
+    }
+}
+
 static void bench_field_normalize_weak(void* arg, int iters) {
     int i;
     bench_inv *data = (bench_inv*)arg;
@@ -449,6 +460,7 @@ int main(int argc, char **argv) {
 
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "half")) run_benchmark("field_half", bench_field_half, bench_setup, NULL, &data, 10, iters*100);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize", bench_field_normalize, bench_setup, NULL, &data, 10, iters*100);
+    if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize_var", bench_field_normalize_var, bench_setup, NULL, &data, 10, iters*100);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "normalize")) run_benchmark("field_normalize_weak", bench_field_normalize_weak, bench_setup, NULL, &data, 10, iters*100);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "sqr")) run_benchmark("field_sqr", bench_field_sqr, bench_setup, NULL, &data, 10, iters*10);
     if (d || have_flag(argc, argv, "field") || have_flag(argc, argv, "mul")) run_benchmark("field_mul", bench_field_mul, bench_setup, NULL, &data, 10, iters*10);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/ctime_tests.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/ctime_tests.c
@@ -48,6 +48,11 @@
 #include "../include/secp256k1_ecdsa_adaptor.h"
 #endif
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 static void run_tests(rustsecp256k1zkp_v0_11_0_context *ctx, unsigned char *key);
 
 int main(void) {
@@ -357,3 +362,7 @@ static void run_tests(rustsecp256k1zkp_v0_11_0_context *ctx, unsigned char *key)
     }
 #endif
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/ecdsa_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/ecdsa_impl.h
@@ -273,14 +273,12 @@ static int rustsecp256k1zkp_v0_11_0_ecdsa_sig_verify(const rustsecp256k1zkp_v0_1
 
 static int rustsecp256k1zkp_v0_11_0_ecdsa_sig_sign(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ctx, rustsecp256k1zkp_v0_11_0_scalar *sigr, rustsecp256k1zkp_v0_11_0_scalar *sigs, const rustsecp256k1zkp_v0_11_0_scalar *seckey, const rustsecp256k1zkp_v0_11_0_scalar *message, const rustsecp256k1zkp_v0_11_0_scalar *nonce, int *recid) {
     unsigned char b[32];
-    rustsecp256k1zkp_v0_11_0_gej rp;
     rustsecp256k1zkp_v0_11_0_ge r;
     rustsecp256k1zkp_v0_11_0_scalar n;
     int overflow = 0;
     int high;
 
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(ctx, &rp, nonce);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&r, &rp);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(ctx, &r, nonce);
     rustsecp256k1zkp_v0_11_0_fe_normalize(&r.x);
     rustsecp256k1zkp_v0_11_0_fe_normalize(&r.y);
     rustsecp256k1zkp_v0_11_0_fe_get_b32(b, &r.x);
@@ -296,7 +294,6 @@ static int rustsecp256k1zkp_v0_11_0_ecdsa_sig_sign(const rustsecp256k1zkp_v0_11_
     rustsecp256k1zkp_v0_11_0_scalar_inverse(sigs, nonce);
     rustsecp256k1zkp_v0_11_0_scalar_mul(sigs, sigs, &n);
     rustsecp256k1zkp_v0_11_0_scalar_clear(&n);
-    rustsecp256k1zkp_v0_11_0_gej_clear(&rp);
     rustsecp256k1zkp_v0_11_0_ge_clear(&r);
     high = rustsecp256k1zkp_v0_11_0_scalar_is_high(sigs);
     rustsecp256k1zkp_v0_11_0_scalar_cond_negate(sigs, high);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/ecmult_gen.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/ecmult_gen.h
@@ -137,7 +137,8 @@ static void rustsecp256k1zkp_v0_11_0_ecmult_gen_context_build(rustsecp256k1zkp_v
 static void rustsecp256k1zkp_v0_11_0_ecmult_gen_context_clear(rustsecp256k1zkp_v0_11_0_ecmult_gen_context* ctx);
 
 /** Multiply with the generator: R = a*G */
-static void rustsecp256k1zkp_v0_11_0_ecmult_gen(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context* ctx, rustsecp256k1zkp_v0_11_0_gej *r, const rustsecp256k1zkp_v0_11_0_scalar *a);
+static void rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context* ctx, rustsecp256k1zkp_v0_11_0_gej *r, const rustsecp256k1zkp_v0_11_0_scalar *a);
+static void rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context* ctx, rustsecp256k1zkp_v0_11_0_ge *r, const rustsecp256k1zkp_v0_11_0_scalar *a);
 
 static void rustsecp256k1zkp_v0_11_0_ecmult_gen_blind(rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ctx, const rustsecp256k1zkp_v0_11_0_hash_ctx *hash_ctx, const unsigned char *seed32);
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/ecmult_gen_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/ecmult_gen_impl.h
@@ -51,7 +51,7 @@ static void rustsecp256k1zkp_v0_11_0_ecmult_gen_scalar_diff(rustsecp256k1zkp_v0_
     rustsecp256k1zkp_v0_11_0_scalar_add(diff, diff, &neghalf);
 }
 
-static void rustsecp256k1zkp_v0_11_0_ecmult_gen(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ctx, rustsecp256k1zkp_v0_11_0_gej *r, const rustsecp256k1zkp_v0_11_0_scalar *gn) {
+static void rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ctx, rustsecp256k1zkp_v0_11_0_gej *r, const rustsecp256k1zkp_v0_11_0_scalar *gn) {
     uint32_t comb_off;
     rustsecp256k1zkp_v0_11_0_ge add;
     rustsecp256k1zkp_v0_11_0_fe neg;
@@ -281,11 +281,19 @@ static void rustsecp256k1zkp_v0_11_0_ecmult_gen(const rustsecp256k1zkp_v0_11_0_e
     rustsecp256k1zkp_v0_11_0_memclear_explicit(&recoded, sizeof(recoded));
 }
 
+SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ctx, rustsecp256k1zkp_v0_11_0_ge *r, const rustsecp256k1zkp_v0_11_0_scalar *a) {
+    rustsecp256k1zkp_v0_11_0_gej rj;
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(ctx, &rj, a);
+    rustsecp256k1zkp_v0_11_0_ge_set_gej(r, &rj);
+    /* Jacobian coordinates resulting from our multiplication algorithm could potentially leak
+     * information about the secret input scalar, so clear the memory out to be on the safe side. */
+    rustsecp256k1zkp_v0_11_0_gej_clear(&rj);
+}
+
 /* Setup blinding values for rustsecp256k1zkp_v0_11_0_ecmult_gen. */
 static void rustsecp256k1zkp_v0_11_0_ecmult_gen_blind(rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ctx, const rustsecp256k1zkp_v0_11_0_hash_ctx *hash_ctx, const unsigned char *seed32) {
     rustsecp256k1zkp_v0_11_0_scalar b;
     rustsecp256k1zkp_v0_11_0_scalar diff;
-    rustsecp256k1zkp_v0_11_0_gej gb;
     rustsecp256k1zkp_v0_11_0_fe f;
     unsigned char nonce32[32];
     rustsecp256k1zkp_v0_11_0_rfc6979_hmac_sha256 rng;
@@ -325,15 +333,13 @@ static void rustsecp256k1zkp_v0_11_0_ecmult_gen_blind(rustsecp256k1zkp_v0_11_0_e
      * which rustsecp256k1zkp_v0_11_0_gej_add_ge cannot handle. */
     rustsecp256k1zkp_v0_11_0_scalar_cmov(&b, &rustsecp256k1zkp_v0_11_0_scalar_one, rustsecp256k1zkp_v0_11_0_scalar_is_zero(&b));
     rustsecp256k1zkp_v0_11_0_rfc6979_hmac_sha256_finalize(&rng);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(ctx, &gb, &b);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(ctx, &ctx->ge_offset, &b);
     rustsecp256k1zkp_v0_11_0_scalar_negate(&b, &b);
     rustsecp256k1zkp_v0_11_0_scalar_add(&ctx->scalar_offset, &b, &diff);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&ctx->ge_offset, &gb);
 
     /* Clean up. */
     rustsecp256k1zkp_v0_11_0_memclear_explicit(nonce32, sizeof(nonce32));
     rustsecp256k1zkp_v0_11_0_scalar_clear(&b);
-    rustsecp256k1zkp_v0_11_0_gej_clear(&gb);
     rustsecp256k1zkp_v0_11_0_fe_clear(&f);
     rustsecp256k1zkp_v0_11_0_rfc6979_hmac_sha256_clear(&rng);
 }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/field.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/field.h
@@ -166,7 +166,7 @@ static int rustsecp256k1zkp_v0_11_0_fe_is_odd(const rustsecp256k1zkp_v0_11_0_fe 
 /** Determine whether two field elements are equal.
  *
  * On input, a and b must be valid field elements with magnitudes not exceeding
- * 1 and 31, respectively.
+ * 1 and 30, respectively.
  * Returns a = b (mod p).
  */
 static int rustsecp256k1zkp_v0_11_0_fe_equal(const rustsecp256k1zkp_v0_11_0_fe *a, const rustsecp256k1zkp_v0_11_0_fe *b);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/field_5x52_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/field_5x52_impl.h
@@ -338,11 +338,11 @@ SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_fe_impl_add(rustsecp256k1z
     r->n[4] += a->n[4];
 }
 
-SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_fe_impl_mul(rustsecp256k1zkp_v0_11_0_fe *r, const rustsecp256k1zkp_v0_11_0_fe *a, const rustsecp256k1zkp_v0_11_0_fe * SECP256K1_RESTRICT b) {
+SECP256K1_FORCE_INLINE static void rustsecp256k1zkp_v0_11_0_fe_impl_mul(rustsecp256k1zkp_v0_11_0_fe *r, const rustsecp256k1zkp_v0_11_0_fe *a, const rustsecp256k1zkp_v0_11_0_fe * SECP256K1_RESTRICT b) {
     rustsecp256k1zkp_v0_11_0_fe_mul_inner(r->n, a->n, b->n);
 }
 
-SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_fe_impl_sqr(rustsecp256k1zkp_v0_11_0_fe *r, const rustsecp256k1zkp_v0_11_0_fe *a) {
+SECP256K1_FORCE_INLINE static void rustsecp256k1zkp_v0_11_0_fe_impl_sqr(rustsecp256k1zkp_v0_11_0_fe *r, const rustsecp256k1zkp_v0_11_0_fe *a) {
     rustsecp256k1zkp_v0_11_0_fe_sqr_inner(r->n, a->n);
 }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/field_5x52_int128_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/field_5x52_int128_impl.h
@@ -15,7 +15,7 @@
 #define VERIFY_BITS(x, n) VERIFY_CHECK(((x) >> (n)) == 0)
 #define VERIFY_BITS_128(x, n) VERIFY_CHECK(rustsecp256k1zkp_v0_11_0_u128_check_bits((x), (n)))
 
-SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_fe_mul_inner(uint64_t *r, const uint64_t *a, const uint64_t * SECP256K1_RESTRICT b) {
+SECP256K1_FORCE_INLINE static void rustsecp256k1zkp_v0_11_0_fe_mul_inner(uint64_t *r, const uint64_t *a, const uint64_t * SECP256K1_RESTRICT b) {
     rustsecp256k1zkp_v0_11_0_uint128 c, d;
     uint64_t t3, t4, tx, u0;
     uint64_t a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4];
@@ -151,7 +151,7 @@ SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_fe_mul_inner(uint64_t *r, 
     /* [r4 r3 r2 r1 r0] = [p8 p7 p6 p5 p4 p3 p2 p1 p0] */
 }
 
-SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_fe_sqr_inner(uint64_t *r, const uint64_t *a) {
+SECP256K1_FORCE_INLINE static void rustsecp256k1zkp_v0_11_0_fe_sqr_inner(uint64_t *r, const uint64_t *a) {
     rustsecp256k1zkp_v0_11_0_uint128 c, d;
     uint64_t a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3], a4 = a[4];
     uint64_t t3, t4, tx, u0;

--- a/secp256k1-zkp-sys/depend/secp256k1/src/field_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/field_impl.h
@@ -27,7 +27,7 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_fe_equal(const rustsecp256k
     SECP256K1_FE_VERIFY(a);
     SECP256K1_FE_VERIFY(b);
     SECP256K1_FE_VERIFY_MAGNITUDE(a, 1);
-    SECP256K1_FE_VERIFY_MAGNITUDE(b, 31);
+    SECP256K1_FE_VERIFY_MAGNITUDE(b, 30);
 
     rustsecp256k1zkp_v0_11_0_fe_negate(&na, a, 1);
     rustsecp256k1zkp_v0_11_0_fe_add(&na, b);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/bppp/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/bppp/main_impl.h
@@ -28,6 +28,11 @@ rustsecp256k1zkp_v0_11_0_bppp_generators *rustsecp256k1zkp_v0_11_0_bppp_generato
     if (ret == NULL) {
         return NULL;
     }
+    /* Ensure that multiplication will not wrap around */
+    if (n > SIZE_MAX / sizeof(*ret->gens)) {
+        free(ret);
+        return NULL;
+    }
     ret->gens = checked_malloc(&ctx->error_callback, n * sizeof(*ret->gens));
     if (ret->gens == NULL) {
         free(ret);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/bppp/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/bppp/tests_impl.h
@@ -28,6 +28,8 @@ static void test_bppp_generators_api(void) {
     CHECK(gens != NULL);
     gens_orig = gens; /* Preserve for round-trip test */
 
+    CHECK(rustsecp256k1zkp_v0_11_0_bppp_generators_create(CTX, SIZE_MAX / sizeof(rustsecp256k1zkp_v0_11_0_ge) + 1) == NULL);
+
     /* Serialize */
     CHECK_ILLEGAL(CTX, rustsecp256k1zkp_v0_11_0_bppp_generators_serialize(CTX, NULL, gens_ser, &len));
     CHECK_ILLEGAL(CTX, rustsecp256k1zkp_v0_11_0_bppp_generators_serialize(CTX, gens, NULL, &len));
@@ -662,6 +664,34 @@ static void norm_arg_test_all(void) {
     norm_arg_test(64, 64);
 }
 
+DEFINE_SHA256_TRANSFORM_PROBE(sha256_bppp)
+static void test_bppp_ctx_sha256(void) {
+    /* Check ctx-provided SHA256 compression override takes effect */
+    rustsecp256k1zkp_v0_11_0_context *ctx = rustsecp256k1zkp_v0_11_0_context_clone(CTX);
+    unsigned char out_default[66], out_custom[66];
+    rustsecp256k1zkp_v0_11_0_bppp_generators *gens;
+    size_t len = sizeof(out_default);
+
+    /* Default behavior. No ctx-provided SHA256 compression */
+    gens = rustsecp256k1zkp_v0_11_0_bppp_generators_create(ctx, 2);
+    CHECK(gens != NULL);
+    CHECK(rustsecp256k1zkp_v0_11_0_bppp_generators_serialize(ctx, gens, out_default, &len));
+    rustsecp256k1zkp_v0_11_0_bppp_generators_destroy(ctx, gens);
+    CHECK(!sha256_bppp_called);
+
+    /* Override SHA256 compression directly, bypassing the ctx setter sanity checks */
+    ctx->hash_ctx.fn_sha256_compression = sha256_bppp;
+    gens = rustsecp256k1zkp_v0_11_0_bppp_generators_create(ctx, 2);
+    CHECK(gens != NULL);
+    CHECK(rustsecp256k1zkp_v0_11_0_bppp_generators_serialize(ctx, gens, out_custom, &len));
+    rustsecp256k1zkp_v0_11_0_bppp_generators_destroy(ctx, gens);
+    CHECK(sha256_bppp_called);
+    /* Outputs must differ if custom compression was used */
+    CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(out_default, out_custom, 66) != 0);
+
+    rustsecp256k1zkp_v0_11_0_context_destroy(ctx);
+}
+
 /* --- Test registry --- */
 static const struct tf_test_entry tests_bppp[] = {
     CASE1(test_log_exp),
@@ -674,6 +704,7 @@ static const struct tf_test_entry tests_bppp[] = {
     CASE1(norm_arg_test_all),
     CASE1(norm_arg_verify_vectors),
     CASE1(norm_arg_prove_vectors),
+    CASE1(test_bppp_ctx_sha256),
 };
 
 #endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdh/Makefile.am.include
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdh/Makefile.am.include
@@ -1,5 +1,6 @@
 include_HEADERS += include/rustsecp256k1zkp_v0_11_0_ecdh.h
 noinst_HEADERS += src/modules/ecdh/main_impl.h
 noinst_HEADERS += src/modules/ecdh/tests_impl.h
+noinst_HEADERS += src/modules/ecdh/tests_exhaustive_impl.h
 noinst_HEADERS += src/modules/ecdh/bench_impl.h
 noinst_HEADERS += src/wycheproof/ecdh_rustsecp256k1zkp_v0_11_0_test.h

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdh/tests_exhaustive_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdh/tests_exhaustive_impl.h
@@ -1,0 +1,56 @@
+/***********************************************************************
+ * Distributed under the MIT software license, see the accompanying    *
+ * file COPYING or https://www.opensource.org/licenses/mit-license.php.*
+ ***********************************************************************/
+
+#ifndef SECP256K1_MODULE_ECDH_TESTS_EXHAUSTIVE_H
+#define SECP256K1_MODULE_ECDH_TESTS_EXHAUSTIVE_H
+
+#include "../../../include/secp256k1_ecdh.h"
+#include "main_impl.h"
+
+static void test_exhaustive_ecdh(const rustsecp256k1zkp_v0_11_0_context *ctx, const rustsecp256k1zkp_v0_11_0_ge *group) {
+    int i, j;
+    unsigned char seckeys[EXHAUSTIVE_TEST_ORDER - 1][32];
+    rustsecp256k1zkp_v0_11_0_pubkey pubkeys[EXHAUSTIVE_TEST_ORDER - 1];
+
+    /* Construct key pairs (32-byte secret key, public key object) for the entire group. */
+    for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {
+        rustsecp256k1zkp_v0_11_0_scalar scalar;
+        rustsecp256k1zkp_v0_11_0_scalar_set_int(&scalar, i);
+        rustsecp256k1zkp_v0_11_0_scalar_get_b32(seckeys[i - 1], &scalar);
+        CHECK(rustsecp256k1zkp_v0_11_0_ec_pubkey_create(ctx, &pubkeys[i - 1], seckeys[i - 1]));
+    }
+
+    /* Loop over key combinations. */
+    for (i = 1; i < EXHAUSTIVE_TEST_ORDER; i++) {
+        for (j = 1; j < EXHAUSTIVE_TEST_ORDER; j++) {
+            unsigned char ecdh_result_ij[32];
+            unsigned char ecdh_result_ji[32];
+
+            /* Calculate ECDH(i*G, j) and ECDH(j*G, i) using API function and verify that the results match. */
+            CHECK(rustsecp256k1zkp_v0_11_0_ecdh(ctx, ecdh_result_ij, &pubkeys[i - 1], seckeys[j - 1], NULL, NULL));
+            CHECK(rustsecp256k1zkp_v0_11_0_ecdh(ctx, ecdh_result_ji, &pubkeys[j - 1], seckeys[i - 1], NULL, NULL));
+            CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(ecdh_result_ij, ecdh_result_ji, 32) == 0);
+
+            /* Recalculate the expected ECDH result manually by invoking the default ECDH hash
+             * function on the precomputed group element (group[i * j]) coordinates, and verify
+             * that it matches the previously calculated public API results. */
+            {
+                rustsecp256k1zkp_v0_11_0_ge ecdh_ge_expected = group[(i * j) % EXHAUSTIVE_TEST_ORDER];
+                unsigned char ecdh_result_expected[32];
+                unsigned char x[32];
+                unsigned char y[32];
+
+                rustsecp256k1zkp_v0_11_0_fe_normalize_var(&ecdh_ge_expected.x);
+                rustsecp256k1zkp_v0_11_0_fe_normalize_var(&ecdh_ge_expected.y);
+                rustsecp256k1zkp_v0_11_0_fe_get_b32(x, &ecdh_ge_expected.x);
+                rustsecp256k1zkp_v0_11_0_fe_get_b32(y, &ecdh_ge_expected.y);
+                CHECK(rustsecp256k1zkp_v0_11_0_ecdh_hash_function_default(ecdh_result_expected, x, y, NULL));
+                CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(ecdh_result_ij, ecdh_result_expected, 32) == 0);
+            }
+        }
+    }
+}
+
+#endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_adaptor/dleq_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_adaptor/dleq_impl.h
@@ -82,9 +82,12 @@ static void rustsecp256k1zkp_v0_11_0_dleq_challenge(const rustsecp256k1zkp_v0_11
 static void rustsecp256k1zkp_v0_11_0_dleq_pair(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ecmult_gen_ctx, rustsecp256k1zkp_v0_11_0_ge *p, const rustsecp256k1zkp_v0_11_0_scalar *sk, const rustsecp256k1zkp_v0_11_0_ge *gen2) {
     rustsecp256k1zkp_v0_11_0_gej pj[2];
 
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(ecmult_gen_ctx, &pj[0], sk);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(ecmult_gen_ctx, &pj[0], sk);
     rustsecp256k1zkp_v0_11_0_ecmult_const(&pj[1], gen2, sk);
     rustsecp256k1zkp_v0_11_0_ge_set_all_gej(p, pj, 2);
+
+    rustsecp256k1zkp_v0_11_0_gej_clear(&pj[0]);
+    rustsecp256k1zkp_v0_11_0_gej_clear(&pj[1]);
 }
 
 /* Generates a proof that the discrete logarithm of P1 to the secp256k1 base G is the

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_adaptor/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_adaptor/main_impl.h
@@ -196,9 +196,12 @@ int rustsecp256k1zkp_v0_11_0_ecdsa_adaptor_encrypt(const rustsecp256k1zkp_v0_11_
     /* R := k*Y */
     rustsecp256k1zkp_v0_11_0_ecmult_const(&rj[0], &enckey_ge, &k);
     /* R' := k*G */
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &rj[1], &k);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&ctx->ecmult_gen_ctx, &rj[1], &k);
 
     rustsecp256k1zkp_v0_11_0_ge_set_all_gej(r, rj, 2);
+
+    rustsecp256k1zkp_v0_11_0_gej_clear(&rj[0]);
+    rustsecp256k1zkp_v0_11_0_gej_clear(&rj[1]);
 
     /* We declassify the non-secret nonce values to allow using them as branch points. */
     rustsecp256k1zkp_v0_11_0_declassify(ctx, &r[0], sizeof(r[0]));
@@ -325,7 +328,6 @@ int rustsecp256k1zkp_v0_11_0_ecdsa_adaptor_recover(const rustsecp256k1zkp_v0_11_
     rustsecp256k1zkp_v0_11_0_scalar deckey;
     rustsecp256k1zkp_v0_11_0_ge enckey_expected_ge;
     rustsecp256k1zkp_v0_11_0_ge enckey_ge;
-    rustsecp256k1zkp_v0_11_0_gej enckey_expected_gej;
     unsigned char enckey33[33];
     unsigned char enckey_expected33[33];
     int ret = 1;
@@ -349,8 +351,7 @@ int rustsecp256k1zkp_v0_11_0_ecdsa_adaptor_recover(const rustsecp256k1zkp_v0_11_
     rustsecp256k1zkp_v0_11_0_scalar_mul(&deckey, &deckey, &sp);
 
     /* Deal with ECDSA malleability */
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &enckey_expected_gej, &deckey);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&enckey_expected_ge, &enckey_expected_gej);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &enckey_expected_ge, &deckey);
     /* We declassify non-secret enckey_expected_ge to allow using it as a
      * branch point. */
     rustsecp256k1zkp_v0_11_0_declassify(ctx, &enckey_expected_ge, sizeof(enckey_expected_ge));

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_adaptor/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_adaptor/tests_impl.h
@@ -12,11 +12,9 @@ static void rand_scalar(rustsecp256k1zkp_v0_11_0_scalar *scalar) {
 
 static void rand_point(rustsecp256k1zkp_v0_11_0_ge *point) {
     rustsecp256k1zkp_v0_11_0_scalar x;
-    rustsecp256k1zkp_v0_11_0_gej pointj;
     rand_scalar(&x);
 
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pointj, &x);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(point, &pointj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, point, &x);
 }
 
 static void dleq_nonce_bitflip(unsigned char **args, size_t n_flip, size_t n_bytes) {
@@ -1184,6 +1182,30 @@ static void adaptor_test_issue335(void) {
     }
 }
 
+DEFINE_SHA256_TRANSFORM_PROBE(sha256_ecdsa_adaptor)
+static void test_ecdsa_adaptor_ctx_sha256(void) {
+    /* Check ctx-provided SHA256 compression override takes effect */
+    rustsecp256k1zkp_v0_11_0_context *ctx = rustsecp256k1zkp_v0_11_0_context_clone(CTX);
+    unsigned char out_default[162], out_custom[162];
+    unsigned char sk[32] = {1}, msg32[32] = {1};
+    unsigned char enckey_sk[32] = {2};
+    rustsecp256k1zkp_v0_11_0_pubkey enckey;
+    CHECK(rustsecp256k1zkp_v0_11_0_ec_pubkey_create(ctx, &enckey, enckey_sk));
+
+    /* Default behavior. No ctx-provided SHA256 compression */
+    CHECK(rustsecp256k1zkp_v0_11_0_ecdsa_adaptor_encrypt(ctx, out_default, sk, &enckey, msg32, NULL, NULL));
+    CHECK(!sha256_ecdsa_adaptor_called);
+
+    /* Override SHA256 compression directly, bypassing the ctx setter sanity checks */
+    ctx->hash_ctx.fn_sha256_compression = sha256_ecdsa_adaptor;
+    CHECK(rustsecp256k1zkp_v0_11_0_ecdsa_adaptor_encrypt(ctx, out_custom, sk, &enckey, msg32, NULL, NULL));
+    CHECK(sha256_ecdsa_adaptor_called);
+    /* Outputs must differ if custom compression was used */
+    CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(out_default, out_custom, 162) != 0);
+
+    rustsecp256k1zkp_v0_11_0_context_destroy(ctx);
+}
+
 /* --- Test registry --- */
 REPEAT_TEST(dleq_tests)
 REPEAT_TEST(adaptor_tests)
@@ -1197,6 +1219,7 @@ static const struct tf_test_entry tests_ecdsa_adaptor[] = {
     CASE1(adaptor_tests),
     CASE1(multi_hop_lock_tests),
     CASE1(adaptor_test_issue335),
+    CASE1(test_ecdsa_adaptor_ctx_sha256),
 };
 
 #endif /* SECP256K1_MODULE_ECDSA_ADAPTOR_TESTS_H */

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_s2c/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_s2c/main_impl.h
@@ -146,7 +146,6 @@ int rustsecp256k1zkp_v0_11_0_ecdsa_anti_exfil_host_commit(const rustsecp256k1zkp
 int rustsecp256k1zkp_v0_11_0_ecdsa_anti_exfil_signer_commit(const rustsecp256k1zkp_v0_11_0_context* ctx, rustsecp256k1zkp_v0_11_0_ecdsa_s2c_opening* opening, const unsigned char* msg32, const unsigned char* seckey32, const unsigned char* rand_commitment32) {
     unsigned char nonce32[32];
     rustsecp256k1zkp_v0_11_0_scalar k;
-    rustsecp256k1zkp_v0_11_0_gej rj;
     rustsecp256k1zkp_v0_11_0_ge r;
     unsigned int count = 0;
     int is_nonce_valid = 0;
@@ -170,11 +169,10 @@ int rustsecp256k1zkp_v0_11_0_ecdsa_anti_exfil_signer_commit(const rustsecp256k1z
         count++;
     }
 
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &rj, &k);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&r, &rj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &r, &k);
     rustsecp256k1zkp_v0_11_0_ecdsa_s2c_opening_save(opening, &r);
-    rustsecp256k1zkp_v0_11_0_memclear_explicit(nonce32, 32);
     rustsecp256k1zkp_v0_11_0_scalar_clear(&k);
+    rustsecp256k1zkp_v0_11_0_memclear_explicit(nonce32, 32);
     return 1;
 }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_s2c/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/ecdsa_s2c/tests_impl.h
@@ -325,6 +325,27 @@ static void test_ecdsa_anti_exfil(void) {
     }
 }
 
+DEFINE_SHA256_TRANSFORM_PROBE(sha256_ecdsa_s2c)
+static void test_ecdsa_s2c_ctx_sha256(void) {
+    /* Check ctx-provided SHA256 compression override takes effect */
+    rustsecp256k1zkp_v0_11_0_context *ctx = rustsecp256k1zkp_v0_11_0_context_clone(CTX);
+    rustsecp256k1zkp_v0_11_0_ecdsa_signature out_default, out_custom;
+    unsigned char sk[32] = {1}, msg32[32] = {1}, s2c_data[32] = {1};
+
+    /* Default behavior. No ctx-provided SHA256 compression */
+    CHECK(rustsecp256k1zkp_v0_11_0_ecdsa_s2c_sign(ctx, &out_default, NULL, msg32, sk, s2c_data));
+    CHECK(!sha256_ecdsa_s2c_called);
+
+    /* Override SHA256 compression directly, bypassing the ctx setter sanity checks */
+    ctx->hash_ctx.fn_sha256_compression = sha256_ecdsa_s2c;
+    CHECK(rustsecp256k1zkp_v0_11_0_ecdsa_s2c_sign(ctx, &out_custom, NULL, msg32, sk, s2c_data));
+    CHECK(sha256_ecdsa_s2c_called);
+    /* Outputs must differ if custom compression was used */
+    CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(out_default.data, out_custom.data, 64) != 0);
+
+    rustsecp256k1zkp_v0_11_0_context_destroy(ctx);
+}
+
 /* --- Test registry --- */
 static const struct tf_test_entry tests_ecdsa_s2c[] = {
     CASE1(run_s2c_opening_test),
@@ -333,7 +354,8 @@ static const struct tf_test_entry tests_ecdsa_s2c[] = {
     CASE1(test_ecdsa_s2c_fixed_vectors),
     CASE1(test_ecdsa_s2c_sign_verify),
     CASE1(test_ecdsa_anti_exfil_signer_commit),
-    CASE1(test_ecdsa_anti_exfil)
+    CASE1(test_ecdsa_anti_exfil),
+    CASE1(test_ecdsa_s2c_ctx_sha256),
 };
 
 #endif /* SECP256K1_MODULE_ECDSA_S2C_TESTS_H */

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/generator/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/generator/main_impl.h
@@ -217,7 +217,8 @@ static int rustsecp256k1zkp_v0_11_0_generator_generate_internal(const rustsecp25
         rustsecp256k1zkp_v0_11_0_scalar blind;
         rustsecp256k1zkp_v0_11_0_scalar_set_b32(&blind, blind32, &overflow);
         ret = !overflow;
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &accum, &blind);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&ctx->ecmult_gen_ctx, &accum, &blind);
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blind);
     }
 
     rustsecp256k1zkp_v0_11_0_sha256_initialize(&sha256);
@@ -243,6 +244,8 @@ static int rustsecp256k1zkp_v0_11_0_generator_generate_internal(const rustsecp25
     rustsecp256k1zkp_v0_11_0_gej_add_ge(&accum, &accum, &add);
 
     rustsecp256k1zkp_v0_11_0_ge_set_gej(&add, &accum);
+    rustsecp256k1zkp_v0_11_0_gej_clear(&accum);
+
     rustsecp256k1zkp_v0_11_0_generator_save(gen, &add);
     return ret;
 }
@@ -354,6 +357,8 @@ int rustsecp256k1zkp_v0_11_0_pedersen_blind_sum(const rustsecp256k1zkp_v0_11_0_c
     for (i = 0; i < n; i++) {
         rustsecp256k1zkp_v0_11_0_scalar_set_b32(&x, blinds[i], &overflow);
         if (overflow) {
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&acc);
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&x);
             return 0;
         }
         if (i >= npositive) {

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/generator/pedersen_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/generator/pedersen_impl.h
@@ -41,7 +41,7 @@ static void rustsecp256k1zkp_v0_11_0_pedersen_ecmult_small(rustsecp256k1zkp_v0_1
 /* sec * G + value * G2. */
 SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_pedersen_ecmult(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ecmult_gen_ctx, rustsecp256k1zkp_v0_11_0_gej *rj, const rustsecp256k1zkp_v0_11_0_scalar *sec, uint64_t value, const rustsecp256k1zkp_v0_11_0_ge* genp) {
     rustsecp256k1zkp_v0_11_0_gej vj;
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(ecmult_gen_ctx, rj, sec);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(ecmult_gen_ctx, rj, sec);
     rustsecp256k1zkp_v0_11_0_pedersen_ecmult_small(&vj, value, genp);
     /* FIXME: constant time. */
     rustsecp256k1zkp_v0_11_0_gej_add_var(rj, rj, &vj, NULL);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/musig/session_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/musig/session_impl.h
@@ -415,7 +415,7 @@ static int rustsecp256k1zkp_v0_11_0_musig_nonce_gen_internal(const rustsecp256k1
 
     /* Compute pubnonce as two gejs */
     for (i = 0; i < 2; i++) {
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &nonce_ptj[i], &k[i]);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&ctx->ecmult_gen_ctx, &nonce_ptj[i], &k[i]);
         rustsecp256k1zkp_v0_11_0_scalar_clear(&k[i]);
     }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/musig/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/musig/tests_impl.h
@@ -381,7 +381,7 @@ static void musig_api_tests(void) {
         rustsecp256k1zkp_v0_11_0_ge aggnonce_pt[2];
         rustsecp256k1zkp_v0_11_0_musig_aggnonce_load(CTX, aggnonce_pt, &aggnonce);
         for (i = 0; i < 2; i++) {
-            rustsecp256k1zkp_v0_11_0_ge_is_infinity(&aggnonce_pt[i]);
+            CHECK(rustsecp256k1zkp_v0_11_0_ge_is_infinity(&aggnonce_pt[i]) == 1);
         }
     }
     CHECK(rustsecp256k1zkp_v0_11_0_musig_nonce_agg(CTX, &aggnonce, pubnonce_ptr, 2) == 1);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/rangeproof/borromean_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/rangeproof/borromean_impl.h
@@ -129,9 +129,8 @@ int rustsecp256k1zkp_v0_11_0_borromean_sign(const rustsecp256k1zkp_v0_11_0_hash_
     count = 0;
     for (i = 0; i < nrings; i++) {
         VERIFY_CHECK(INT_MAX - count > rsizes[i]);
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(ecmult_gen_ctx, &rgej, &k[i]);
-        rustsecp256k1zkp_v0_11_0_ge_set_gej(&rge, &rgej);
-        if (rustsecp256k1zkp_v0_11_0_gej_is_infinity(&rgej)) {
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(ecmult_gen_ctx, &rge, &k[i]);
+        if (rustsecp256k1zkp_v0_11_0_ge_is_infinity(&rge)) {
             return 0;
         }
         rustsecp256k1zkp_v0_11_0_eckey_pubkey_serialize33(&rge, tmp);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/rangeproof/rangeproof_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/rangeproof/rangeproof_impl.h
@@ -268,6 +268,8 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_sign_impl(const 
         prep[idx] = 128;
     }
     if (!rustsecp256k1zkp_v0_11_0_rangeproof_genrand(hash_ctx, sec, s, prep, rsizes, rings, nonce, commit, proof, len, genp)) {
+        rustsecp256k1zkp_v0_11_0_memclear_explicit(prep, sizeof(prep));
+        rustsecp256k1zkp_v0_11_0_memclear_explicit(sec, sizeof(sec));
         return 0;
     }
     rustsecp256k1zkp_v0_11_0_memclear_explicit(prep, 4096);
@@ -284,7 +286,10 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_sign_impl(const 
      */
     rustsecp256k1zkp_v0_11_0_scalar_set_b32(&stmp, blind, &overflow);
     rustsecp256k1zkp_v0_11_0_scalar_add(&sec[rings - 1], &sec[rings - 1], &stmp);
+    rustsecp256k1zkp_v0_11_0_scalar_clear(&stmp);
     if (overflow || rustsecp256k1zkp_v0_11_0_scalar_is_zero(&sec[rings - 1])) {
+        rustsecp256k1zkp_v0_11_0_memclear_explicit(sec, sizeof(sec));
+        rustsecp256k1zkp_v0_11_0_memclear_explicit(k, sizeof(k));
         return 0;
     }
     signs = &proof[len];
@@ -298,6 +303,8 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_sign_impl(const 
         /*OPT: Use the precomputed gen2 basis?*/
         rustsecp256k1zkp_v0_11_0_pedersen_ecmult(ecmult_gen_ctx, &pubs[npub], &sec[i], ((uint64_t)secidx[i] * scale) << (i*2), genp);
         if (rustsecp256k1zkp_v0_11_0_gej_is_infinity(&pubs[npub])) {
+            rustsecp256k1zkp_v0_11_0_memclear_explicit(sec, sizeof(sec));
+            rustsecp256k1zkp_v0_11_0_memclear_explicit(k, sizeof(k));
             return 0;
         }
         if (i < rings - 1) {
@@ -323,6 +330,8 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_sign_impl(const 
     rustsecp256k1zkp_v0_11_0_sha256_finalize(hash_ctx, &sha256_m, tmp);
     rustsecp256k1zkp_v0_11_0_sha256_clear(&sha256_m);
     if (!rustsecp256k1zkp_v0_11_0_borromean_sign(hash_ctx, ecmult_gen_ctx, &proof[len], s, pubs, k, sec, rsizes, secidx, rings, tmp, 32)) {
+        rustsecp256k1zkp_v0_11_0_memclear_explicit(sec, sizeof(sec));
+        rustsecp256k1zkp_v0_11_0_memclear_explicit(k, sizeof(k));
         return 0;
     }
     len += 32;
@@ -332,7 +341,8 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_sign_impl(const 
     }
     VERIFY_CHECK(len <= *plen);
     *plen = len;
-    rustsecp256k1zkp_v0_11_0_memclear_explicit(prep, 4096);
+    rustsecp256k1zkp_v0_11_0_memclear_explicit(sec, sizeof(sec));
+    rustsecp256k1zkp_v0_11_0_memclear_explicit(k, sizeof(k));
     return 1;
 }
 
@@ -658,6 +668,7 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_verify_impl(cons
             return 0;
         }
         if (!rustsecp256k1zkp_v0_11_0_rangeproof_rewind_inner(hash_ctx, &blind, &vv, message_out, outlen, evalues, s, rsizes, rings, nonce, commit, proof, offset_post_header, genp)) {
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&blind);
             return 0;
         }
         /* Unwind apparently successful, see if the commitment can be reconstructed. */
@@ -665,11 +676,13 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_verify_impl(cons
         vv = (vv * scale) + *min_value;
         rustsecp256k1zkp_v0_11_0_pedersen_ecmult(ecmult_gen_ctx, &accj, &blind, vv, genp);
         if (rustsecp256k1zkp_v0_11_0_gej_is_infinity(&accj)) {
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&blind);
             return 0;
         }
         rustsecp256k1zkp_v0_11_0_gej_neg(&accj, &accj);
         rustsecp256k1zkp_v0_11_0_gej_add_ge_var(&accj, &accj, commit, NULL);
         if (!rustsecp256k1zkp_v0_11_0_gej_is_infinity(&accj)) {
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&blind);
             return 0;
         }
         if (blindout) {
@@ -678,6 +691,7 @@ SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_rangeproof_verify_impl(cons
         if (value_out) {
             *value_out = vv;
         }
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blind);
     }
     return ret;
 }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/rangeproof/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/rangeproof/tests_impl.h
@@ -162,7 +162,7 @@ static void test_borromean_internal(void) {
                 s[i] = one;
             }
             if (j == secidx[i]) {
-                rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pubs[c + j], &sec[i]);
+                rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &pubs[c + j], &sec[i]);
             } else {
                 testutil_random_ge_test(&ge);
                 testutil_random_ge_jacobian_test(&pubs[c + j],&ge);
@@ -811,35 +811,6 @@ static void test_rangeproof_fixed_vectors(void) {
 }
 }
 
-static void print_vector_helper(unsigned char *buf, size_t buf_len) {
-    size_t j;
-    printf("    ");
-    for (j = 0; j < buf_len; j++) {
-        printf("0x%02x", buf[j]);
-        if (j == buf_len-1) {
-            printf(",\n");
-        } else if ((j+1) % 16 != 0) {
-            printf(", ");
-        } else {
-            printf(",\n");
-            printf("    ");
-        }
-    }
-    printf("};\n");
-}
-
-static void print_vector(int i, unsigned char *proof, size_t p_len, rustsecp256k1zkp_v0_11_0_pedersen_commitment *commit) {
-    unsigned char commit_output[33];
-
-    printf("unsigned char vector_%d[] = {\n", i);
-    print_vector_helper(proof, p_len);
-
-    CHECK(rustsecp256k1zkp_v0_11_0_pedersen_commitment_serialize(CTX, commit_output, commit));
-    printf("unsigned char commit_%d[] = {\n", i);
-    print_vector_helper(commit_output, sizeof(commit_output));
-}
-
-
 /* Use same nonce and blinding value for all "reproducible" test vectors */
 static unsigned char vector_blind[] = {
     0x48, 0x26, 0xad, 0x41, 0x37, 0x4c, 0x25, 0x62, 0x52, 0x14, 0x78, 0x82, 0x89, 0x9c, 0x86, 0x27,
@@ -1233,8 +1204,6 @@ static void test_rangeproof_fixed_vectors_reproducible(void) {
         CHECK(rustsecp256k1zkp_v0_11_0_rangeproof_sign(CTX, proof, &p_len, min_value, &pc, vector_blind, vector_nonce, exp, min_bits, value, message, m_len, NULL, 0, rustsecp256k1zkp_v0_11_0_generator_h));
         CHECK(p_len <= rustsecp256k1zkp_v0_11_0_rangeproof_max_size(CTX, value, min_bits));
         CHECK(p_len == sizeof(proof));
-        /* Uncomment the next line to print the test vector */
-        /* print_vector(0, proof, p_len, &pc); */
         CHECK(p_len == sizeof(vector_0));
         CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(proof, vector_0, p_len) == 0);
 
@@ -1287,8 +1256,6 @@ static void test_rangeproof_fixed_vectors_reproducible(void) {
         CHECK(rustsecp256k1zkp_v0_11_0_rangeproof_sign(CTX, proof, &p_len, min_value, &pc, vector_blind, vector_nonce, exp, min_bits, value, message, m_len, NULL, 0, rustsecp256k1zkp_v0_11_0_generator_h));
         CHECK(p_len <= rustsecp256k1zkp_v0_11_0_rangeproof_max_size(CTX, value, min_bits));
         CHECK(p_len == sizeof(proof));
-        /* Uncomment the next line to print the test vector */
-        /* print_vector(1, proof, p_len, &pc); */
         CHECK(p_len == sizeof(vector_1));
         CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(proof, vector_1, p_len) == 0);
 
@@ -1333,8 +1300,6 @@ static void test_rangeproof_fixed_vectors_reproducible(void) {
         CHECK(rustsecp256k1zkp_v0_11_0_rangeproof_sign(CTX, proof, &p_len, min_value, &pc, vector_blind, vector_nonce, exp, min_bits, value, message, m_len, NULL, 0, rustsecp256k1zkp_v0_11_0_generator_h));
         CHECK(p_len <= rustsecp256k1zkp_v0_11_0_rangeproof_max_size(CTX, value, min_bits));
         CHECK(p_len == sizeof(proof));
-        /* Uncomment the next line to print the test vector */
-        /* print_vector(2, proof, p_len, &pc); */
         CHECK(p_len == sizeof(vector_2));
         CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(proof, vector_2, p_len) == 0);
 
@@ -1354,6 +1319,32 @@ static void test_single_value_proof_all(void) {
     test_single_value_proof(UINT64_MAX);
 }
 
+DEFINE_SHA256_TRANSFORM_PROBE(sha256_rangeproof)
+static void test_rangeproof_ctx_sha256(void) {
+    /* Check ctx-provided SHA256 compression override takes effect */
+    rustsecp256k1zkp_v0_11_0_context *ctx = rustsecp256k1zkp_v0_11_0_context_clone(CTX);
+    unsigned char proof_default[5134], proof_custom[5134];
+    size_t len = sizeof(proof_default);
+    unsigned char blind[32] = {1};
+    rustsecp256k1zkp_v0_11_0_pedersen_commitment commit;
+
+    CHECK(rustsecp256k1zkp_v0_11_0_pedersen_commit(ctx, &commit, blind, 1, rustsecp256k1zkp_v0_11_0_generator_h));
+
+    /* Default behavior. No ctx-provided SHA256 compression */
+    CHECK(rustsecp256k1zkp_v0_11_0_rangeproof_sign(ctx, proof_default, &len, 0, &commit, blind, commit.data, 0, 0, 1, NULL, 0, NULL, 0, rustsecp256k1zkp_v0_11_0_generator_h));
+    CHECK(!sha256_rangeproof_called);
+
+    /* Override SHA256 compression directly, bypassing the ctx setter sanity checks */
+    ctx->hash_ctx.fn_sha256_compression = sha256_rangeproof;
+    len = sizeof(proof_custom);
+    CHECK(rustsecp256k1zkp_v0_11_0_rangeproof_sign(ctx, proof_custom, &len, 0, &commit, blind, commit.data, 0, 0, 1, NULL, 0, NULL, 0, rustsecp256k1zkp_v0_11_0_generator_h));
+    CHECK(sha256_rangeproof_called);
+    /* Outputs must differ if custom compression was used */
+    CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(proof_default, proof_custom, len) != 0);
+
+    rustsecp256k1zkp_v0_11_0_context_destroy(ctx);
+}
+
 /* --- Test registry --- */
 REPEAT_TEST(test_rangeproof_api)
 REPEAT_TEST(test_borromean)
@@ -1367,6 +1358,7 @@ static const struct tf_test_entry tests_rangeproof[] = {
     CASE1(test_rangeproof),
     CASE1(test_rangeproof_null_blinder),
     CASE1(test_multiple_generators),
+    CASE1(test_rangeproof_ctx_sha256),
 };
 
 #endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/schnorrsig/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/schnorrsig/main_impl.h
@@ -123,7 +123,6 @@ static int rustsecp256k1zkp_v0_11_0_schnorrsig_sign_internal(const rustsecp256k1
     rustsecp256k1zkp_v0_11_0_scalar sk;
     rustsecp256k1zkp_v0_11_0_scalar e;
     rustsecp256k1zkp_v0_11_0_scalar k;
-    rustsecp256k1zkp_v0_11_0_gej rj;
     rustsecp256k1zkp_v0_11_0_ge pk;
     rustsecp256k1zkp_v0_11_0_ge r;
     unsigned char nonce32[32] = { 0 };
@@ -160,8 +159,7 @@ static int rustsecp256k1zkp_v0_11_0_schnorrsig_sign_internal(const rustsecp256k1
     ret &= !rustsecp256k1zkp_v0_11_0_scalar_is_zero(&k);
     rustsecp256k1zkp_v0_11_0_scalar_cmov(&k, &rustsecp256k1zkp_v0_11_0_scalar_one, !ret);
 
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &rj, &k);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&r, &rj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &r, &k);
 
     /* We declassify r to allow using it as a branch point. This is fine
      * because r is not a secret. */
@@ -183,7 +181,6 @@ static int rustsecp256k1zkp_v0_11_0_schnorrsig_sign_internal(const rustsecp256k1
     rustsecp256k1zkp_v0_11_0_scalar_clear(&sk);
     rustsecp256k1zkp_v0_11_0_memclear_explicit(seckey, sizeof(seckey));
     rustsecp256k1zkp_v0_11_0_memclear_explicit(nonce32, sizeof(nonce32));
-    rustsecp256k1zkp_v0_11_0_gej_clear(&rj);
 
     return ret;
 }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/schnorrsig_halfagg/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/schnorrsig_halfagg/main_impl.h
@@ -189,7 +189,7 @@ int rustsecp256k1zkp_v0_11_0_schnorrsig_aggverify(const rustsecp256k1zkp_v0_11_0
     if (overflow) {
         return 0;
     }
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &lhs, &s);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&ctx->ecmult_gen_ctx, &lhs, &s);
 
     /* Check that lhs == rhs */
     rustsecp256k1zkp_v0_11_0_gej_neg(&lhs, &lhs);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/schnorrsig_halfagg/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/schnorrsig_halfagg/tests_impl.h
@@ -319,6 +319,42 @@ static void test_schnorrsig_aggregate_overflow_internal(void) {
     }
 }
 
+DEFINE_SHA256_TRANSFORM_PROBE(sha256_schnorrsig_halfagg)
+static void test_schnorrsig_halfagg_ctx_sha256(void) {
+    /* Check ctx-provided SHA256 compression override takes effect */
+    rustsecp256k1zkp_v0_11_0_context *ctx = rustsecp256k1zkp_v0_11_0_context_clone(CTX);
+    unsigned char aggsig_default[96], aggsig_custom[96];
+    unsigned char sk[2][32] = {{1}, {2}};
+    unsigned char msgs[2*32];
+    rustsecp256k1zkp_v0_11_0_keypair keypairs[2];
+    rustsecp256k1zkp_v0_11_0_xonly_pubkey pks[2];
+    unsigned char sigs[2*64];
+    size_t aggsig_len;
+    size_t i;
+
+    memset(msgs, 1, sizeof(msgs));
+    for (i = 0; i < 2; i++) {
+        CHECK(rustsecp256k1zkp_v0_11_0_keypair_create(CTX, &keypairs[i], sk[i]));
+        CHECK(rustsecp256k1zkp_v0_11_0_keypair_xonly_pub(CTX, &pks[i], NULL, &keypairs[i]));
+        CHECK(rustsecp256k1zkp_v0_11_0_schnorrsig_sign32(CTX, &sigs[i*64], &msgs[i*32], &keypairs[i], NULL));
+    }
+
+    /* Default behavior. No ctx-provided SHA256 compression */
+    aggsig_len = sizeof(aggsig_default);
+    CHECK(rustsecp256k1zkp_v0_11_0_schnorrsig_aggregate(ctx, aggsig_default, &aggsig_len, pks, msgs, sigs, 2));
+    CHECK(!sha256_schnorrsig_halfagg_called);
+
+    /* Override SHA256 compression directly, bypassing the ctx setter sanity checks */
+    ctx->hash_ctx.fn_sha256_compression = sha256_schnorrsig_halfagg;
+    aggsig_len = sizeof(aggsig_custom);
+    CHECK(rustsecp256k1zkp_v0_11_0_schnorrsig_aggregate(ctx, aggsig_custom, &aggsig_len, pks, msgs, sigs, 2));
+    CHECK(sha256_schnorrsig_halfagg_called);
+    /* Outputs must differ if custom compression was used */
+    CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(aggsig_default, aggsig_custom, 96) != 0);
+
+    rustsecp256k1zkp_v0_11_0_context_destroy(ctx);
+}
+
 /* --- Test registry --- */
 REPEAT_TEST(test_schnorrsig_aggregate)
 REPEAT_TEST(test_schnorrsig_aggregate_api)
@@ -332,6 +368,7 @@ static const struct tf_test_entry tests_schnorrsig_halfagg[] = {
     CASE1(test_schnorrsig_aggregate_api),
     CASE1(test_schnorrsig_aggregate_unforge),
     CASE1(test_schnorrsig_aggregate_overflow),
+    CASE1(test_schnorrsig_halfagg_ctx_sha256),
 };
 
 #undef N_MAX

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/main_impl.h
@@ -261,10 +261,13 @@ int rustsecp256k1zkp_v0_11_0_surjectionproof_generate(const rustsecp256k1zkp_v0_
     /* Compute secret key */
     rustsecp256k1zkp_v0_11_0_scalar_set_b32(&tmps, input_blinding_key, &overflow);
     if (overflow) {
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&tmps);
         return 0;
     }
     rustsecp256k1zkp_v0_11_0_scalar_set_b32(&blinding_key, output_blinding_key, &overflow);
     if (overflow) {
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&tmps);
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
         return 0;
     }
     /* If any input tag is equal to an output tag, verification will fail, because our ring
@@ -273,20 +276,25 @@ int rustsecp256k1zkp_v0_11_0_surjectionproof_generate(const rustsecp256k1zkp_v0_
      * this at the same time that we relax the max-256-inputs rule. */
     for (i = 0; i < n_ephemeral_input_tags; i++) {
         if (rustsecp256k1zkp_v0_11_0_memcmp_var(ephemeral_input_tags[i].data, ephemeral_output_tag->data, sizeof(ephemeral_output_tag->data)) == 0) {
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&tmps);
+            rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
             return 0;
         }
     }
     rustsecp256k1zkp_v0_11_0_scalar_negate(&tmps, &tmps);
     rustsecp256k1zkp_v0_11_0_scalar_add(&blinding_key, &blinding_key, &tmps);
+    rustsecp256k1zkp_v0_11_0_scalar_clear(&tmps);
 
     /* Compute public keys */
     n_total_pubkeys = rustsecp256k1zkp_v0_11_0_surjectionproof_n_total_inputs(ctx, proof);
 
     if (n_used_pubkeys > n_total_pubkeys || n_total_pubkeys != n_ephemeral_input_tags) {
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
         return 0;
     }
 
     if (rustsecp256k1zkp_v0_11_0_surjection_compute_public_keys(ring_pubkeys, n_used_pubkeys, ephemeral_input_tags, n_total_pubkeys, proof->used_inputs, ephemeral_output_tag, input_index, &ring_input_index) == 0) {
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
         return 0;
     }
 
@@ -294,7 +302,21 @@ int rustsecp256k1zkp_v0_11_0_surjectionproof_generate(const rustsecp256k1zkp_v0_
     rsizes[0] = (int) n_used_pubkeys;
     indices[0] = (int) ring_input_index;
     rustsecp256k1zkp_v0_11_0_surjection_genmessage(hash_ctx, msg32, ephemeral_input_tags, n_total_pubkeys, ephemeral_output_tag);
-    if (rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, borromean_s, n_used_pubkeys, &blinding_key) == 0) {
+    /* Derive every s-value, including the one used as the signing nonce, from
+     * every proof-relevant input to
+     * rustsecp256k1zkp_v0_11_0_surjectionproof_generate. Except with negligible hash-collision
+     * probability, this prevents distinct proof inputs from reusing any
+     * s-value.
+     *
+     * The proof-relevant arguments to rustsecp256k1zkp_v0_11_0_surjectionproof_generate
+     * correspond as follows: proof supplies n_total_pubkeys (proof->n_inputs),
+     * proof->used_inputs, and n_used_pubkeys, while proof->data is output and
+     * proof->initialized is VERIFY-only validation state; ephemeral_input_tags
+     * is committed by msg32; n_ephemeral_input_tags equals n_total_pubkeys as
+     * checked above; ephemeral_output_tag is committed by msg32; input_index
+     * and both blinding keys are passed directly. */
+    if (rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, borromean_s, n_used_pubkeys, n_total_pubkeys, proof->used_inputs, msg32, input_index, input_blinding_key, output_blinding_key) == 0) {
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
         return 0;
     }
     /* Borromean sign will overwrite one of the s values we just generated, so use
@@ -303,11 +325,15 @@ int rustsecp256k1zkp_v0_11_0_surjectionproof_generate(const rustsecp256k1zkp_v0_
     nonce = borromean_s[ring_input_index];
     rustsecp256k1zkp_v0_11_0_scalar_clear(&borromean_s[ring_input_index]);
     if (rustsecp256k1zkp_v0_11_0_borromean_sign(hash_ctx, &ctx->ecmult_gen_ctx, &proof->data[0], borromean_s, ring_pubkeys, &nonce, &blinding_key, rsizes, indices, 1, msg32, 32) == 0) {
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
+        rustsecp256k1zkp_v0_11_0_scalar_clear(&nonce);
         return 0;
     }
     for (i = 0; i < n_used_pubkeys; i++) {
         rustsecp256k1zkp_v0_11_0_scalar_get_b32(&proof->data[32 + 32 * i], &borromean_s[i]);
     }
+    rustsecp256k1zkp_v0_11_0_scalar_clear(&blinding_key);
+    rustsecp256k1zkp_v0_11_0_scalar_clear(&nonce);
     return 1;
 }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/surjection.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/surjection.h
@@ -12,7 +12,7 @@
 
 SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_surjection_genmessage(unsigned char *msg32, rustsecp256k1zkp_v0_11_0_ge *ephemeral_input_tags, size_t n_input_tags, rustsecp256k1zkp_v0_11_0_ge *ephemeral_output_tag);
 
-SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_surjection_genrand(rustsecp256k1zkp_v0_11_0_scalar *s, size_t ns, const rustsecp256k1zkp_v0_11_0_scalar *blinding_key);
+SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_surjection_genrand(const rustsecp256k1zkp_v0_11_0_hash_ctx *hash_ctx, rustsecp256k1zkp_v0_11_0_scalar *s, size_t ns, size_t n_inputs, const unsigned char *used_inputs, const unsigned char *msg32, size_t input_index, const unsigned char *input_blinding_key, const unsigned char *output_blinding_key);
 
 SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_surjection_compute_public_keys(rustsecp256k1zkp_v0_11_0_gej *pubkeys, size_t n_pubkeys, const rustsecp256k1zkp_v0_11_0_ge *input_tags, size_t n_input_tags, const unsigned char *used_tags, const rustsecp256k1zkp_v0_11_0_ge *output_tag, size_t input_index, size_t *ring_input_index);
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/surjection_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/surjection_impl.h
@@ -34,31 +34,52 @@ SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_surjection_genmessage(cons
     rustsecp256k1zkp_v0_11_0_sha256_clear(&sha256_en);
 }
 
-SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_surjection_genrand(const rustsecp256k1zkp_v0_11_0_hash_ctx *hash_ctx, rustsecp256k1zkp_v0_11_0_scalar *s, size_t ns, const rustsecp256k1zkp_v0_11_0_scalar *blinding_key) {
+/* Derive the ring's s-values, one of which is used as the signing nonce, from a
+ * seed that hashes the passed-in arguments. See the call site for how these
+ * correspond to the proof inputs. */
+SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_surjection_genrand(const rustsecp256k1zkp_v0_11_0_hash_ctx *hash_ctx, rustsecp256k1zkp_v0_11_0_scalar *s, size_t ns, size_t n_inputs, const unsigned char *used_inputs, const unsigned char *msg32, size_t input_index, const unsigned char *input_blinding_key, const unsigned char *output_blinding_key) {
     size_t i;
-    unsigned char sec_input[36];
+    size_t used_inputs_len;
+    unsigned char n_inputs_ser[4];
+    unsigned char index_ser[4];
+    unsigned char counter[4];
+    unsigned char seed[32];
+    unsigned char out[32];
     rustsecp256k1zkp_v0_11_0_sha256 sha256_en;
 
+    used_inputs_len = (n_inputs + 7) / 8;
+    rustsecp256k1zkp_v0_11_0_write_be32(n_inputs_ser, (uint32_t)n_inputs);
+    rustsecp256k1zkp_v0_11_0_write_be32(index_ser, (uint32_t)input_index);
+
+    /* Hash the arguments into the seed. */
+    rustsecp256k1zkp_v0_11_0_sha256_initialize(&sha256_en);
+    rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, n_inputs_ser, 4);
+    rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, used_inputs, used_inputs_len);
+    rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, msg32, 32);
+    rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, index_ser, 4);
+    rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, input_blinding_key, 32);
+    rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, output_blinding_key, 32);
+    rustsecp256k1zkp_v0_11_0_sha256_finalize(hash_ctx, &sha256_en, seed);
+    rustsecp256k1zkp_v0_11_0_sha256_clear(&sha256_en);
+
     /* compute s values */
-    rustsecp256k1zkp_v0_11_0_scalar_get_b32(&sec_input[4], blinding_key);
     for (i = 0; i < ns; i++) {
         int overflow = 0;
-        sec_input[0] = i;
-        sec_input[1] = i >> 8;
-        sec_input[2] = i >> 16;
-        sec_input[3] = i >> 24;
-
+        rustsecp256k1zkp_v0_11_0_write_be32(counter, (uint32_t)i);
         rustsecp256k1zkp_v0_11_0_sha256_initialize(&sha256_en);
-        rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, sec_input, 36);
-        rustsecp256k1zkp_v0_11_0_sha256_finalize(hash_ctx, &sha256_en, sec_input);
+        rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, counter, 4);
+        rustsecp256k1zkp_v0_11_0_sha256_write(hash_ctx, &sha256_en, seed, 32);
+        rustsecp256k1zkp_v0_11_0_sha256_finalize(hash_ctx, &sha256_en, out);
         rustsecp256k1zkp_v0_11_0_sha256_clear(&sha256_en);
-        rustsecp256k1zkp_v0_11_0_scalar_set_b32(&s[i], sec_input, &overflow);
+        rustsecp256k1zkp_v0_11_0_scalar_set_b32(&s[i], out, &overflow);
         if (overflow == 1) {
-            rustsecp256k1zkp_v0_11_0_memclear_explicit(sec_input, 32);
+            rustsecp256k1zkp_v0_11_0_memclear_explicit(out, sizeof(out));
+            rustsecp256k1zkp_v0_11_0_memclear_explicit(seed, sizeof(seed));
             return 0;
         }
     }
-    rustsecp256k1zkp_v0_11_0_memclear_explicit(sec_input, 32);
+    rustsecp256k1zkp_v0_11_0_memclear_explicit(out, sizeof(out));
+    rustsecp256k1zkp_v0_11_0_memclear_explicit(seed, sizeof(seed));
     return 1;
 }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/surjection/tests_impl.h
@@ -643,6 +643,182 @@ static void test_gen_verify_all(void) {
     test_gen_verify(SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS, SECP256K1_SURJECTIONPROOF_MAX_USED_INPUTS);
 }
 
+static int surjection_genrand_streams_equal(const rustsecp256k1zkp_v0_11_0_scalar *a, const rustsecp256k1zkp_v0_11_0_scalar *b, size_t n) {
+    size_t i;
+    for (i = 0; i < n; i++) {
+        if (!rustsecp256k1zkp_v0_11_0_scalar_eq(&a[i], &b[i])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int surjection_genrand_stream_all_differ(const rustsecp256k1zkp_v0_11_0_scalar *a, const rustsecp256k1zkp_v0_11_0_scalar *b, size_t n) {
+    size_t i;
+    for (i = 0; i < n; i++) {
+        if (rustsecp256k1zkp_v0_11_0_scalar_eq(&a[i], &b[i])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Test that changing any proof-relevant argument to
+ * rustsecp256k1zkp_v0_11_0_surjectionproof_generate changes every s-value produced by
+ * rustsecp256k1zkp_v0_11_0_surjection_genrand. */
+static void test_surjection_genrand(void) {
+    const rustsecp256k1zkp_v0_11_0_hash_ctx *hash_ctx = rustsecp256k1zkp_v0_11_0_get_hash_context(CTX);
+    const size_t ns = 4;
+    const size_t n_inputs = 5;
+    unsigned char msg_a[32];
+    unsigned char msg_b[32];
+    unsigned char ikey_a[32];
+    unsigned char ikey_b[32];
+    unsigned char okey_a[32];
+    unsigned char okey_b[32];
+    unsigned char used_a[SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS / 8] = { 0 };
+    unsigned char used_b[SECP256K1_SURJECTIONPROOF_MAX_N_INPUTS / 8] = { 0 };
+    rustsecp256k1zkp_v0_11_0_scalar s_base[4];
+    rustsecp256k1zkp_v0_11_0_scalar s_cmp[4];
+
+    /* Baseline inputs, plus a one-bit variant of each. */
+    testrand256(msg_a);
+    memcpy(msg_b, msg_a, 32);
+    msg_b[0] ^= 0x01;
+    testrand256(ikey_a);
+    memcpy(ikey_b, ikey_a, 32);
+    ikey_b[0] ^= 0x01;
+    testrand256(okey_a);
+    memcpy(okey_b, okey_a, 32);
+    okey_b[0] ^= 0x01;
+
+    /* Two used-input bitmaps with the same popcount but a different set. */
+    used_a[0] = 0x0f;  /* inputs {0,1,2,3} */
+    used_b[0] = 0x17;  /* inputs {0,1,2,4} */
+
+    /* Baseline. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_base, ns, n_inputs, used_a, msg_a, 0, ikey_a, okey_a) == 1);
+
+    /* Determinism: identical arguments reproduce the identical stream. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, n_inputs, used_a, msg_a, 0, ikey_a, okey_a) == 1);
+    CHECK(surjection_genrand_streams_equal(s_base, s_cmp, ns));
+
+    /* The message is bound. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, n_inputs, used_a, msg_b, 0, ikey_a, okey_a) == 1);
+    CHECK(surjection_genrand_stream_all_differ(s_base, s_cmp, ns));
+
+    /* The used-input selection is bound. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, n_inputs, used_b, msg_a, 0, ikey_a, okey_a) == 1);
+    CHECK(surjection_genrand_stream_all_differ(s_base, s_cmp, ns));
+
+    /* The total input count is bound even at the same bitmap byte length:
+     * n_inputs = 8 and n_inputs = 5 both use a one-byte bitmap. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, 8, used_a, msg_a, 0, ikey_a, okey_a) == 1);
+    CHECK(surjection_genrand_stream_all_differ(s_base, s_cmp, ns));
+
+    /* The honest input index is bound. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, n_inputs, used_a, msg_a, 1, ikey_a, okey_a) == 1);
+    CHECK(surjection_genrand_stream_all_differ(s_base, s_cmp, ns));
+
+    /* The input blinding key is bound. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, n_inputs, used_a, msg_a, 0, ikey_b, okey_a) == 1);
+    CHECK(surjection_genrand_stream_all_differ(s_base, s_cmp, ns));
+
+    /* The output blinding key is bound. */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjection_genrand(hash_ctx, s_cmp, ns, n_inputs, used_a, msg_a, 0, ikey_a, okey_b) == 1);
+    CHECK(surjection_genrand_stream_all_differ(s_base, s_cmp, ns));
+}
+
+/* Changing an unused input tag changes the proof message. Check that every
+ * s-value changes and that both proofs verify. */
+static void test_surjectionproof_generate_changes_s_values(void) {
+    const size_t n_inputs = 3;
+    const size_t n_used = 2;
+    unsigned char seed[32];
+    unsigned char input_blinding_key[3][32] = {{ 0 }};
+    unsigned char output_blinding_key[32] = { 0 };
+    unsigned char reblind[32] = { 0 };
+    rustsecp256k1zkp_v0_11_0_fixed_asset_tag fixed_input_tags[3];
+    rustsecp256k1zkp_v0_11_0_generator ephemeral_input_tags[3];
+    rustsecp256k1zkp_v0_11_0_generator ephemeral_output_tag;
+    rustsecp256k1zkp_v0_11_0_surjectionproof proof_a;
+    rustsecp256k1zkp_v0_11_0_surjectionproof proof_b;
+    size_t input_index;
+    size_t unused_index = n_inputs;
+    size_t i;
+
+    testrand256(seed);
+    for (i = 0; i < n_inputs; i++) {
+        testrand256(fixed_input_tags[i].data);
+        input_blinding_key[i][31] = (unsigned char)i + 1;
+        CHECK(rustsecp256k1zkp_v0_11_0_generator_generate_blinded(CTX, &ephemeral_input_tags[i], fixed_input_tags[i].data, input_blinding_key[i]));
+    }
+    output_blinding_key[31] = 4;
+    reblind[31] = 5;
+    CHECK(rustsecp256k1zkp_v0_11_0_generator_generate_blinded(CTX, &ephemeral_output_tag, fixed_input_tags[1].data, output_blinding_key));
+
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_initialize(CTX, &proof_a, &input_index, fixed_input_tags, n_inputs, n_used, &fixed_input_tags[1], 100, seed) > 0);
+    CHECK(input_index == 1);
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_n_used_inputs(CTX, &proof_a) == n_used);
+    proof_b = proof_a;
+
+    for (i = 0; i < n_inputs; i++) {
+        if (!(proof_a.used_inputs[i / 8] & (1 << (i % 8)))) {
+            unused_index = i;
+        }
+    }
+    CHECK(unused_index < n_inputs);
+
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_generate(CTX, &proof_a, ephemeral_input_tags, n_inputs, &ephemeral_output_tag, input_index, input_blinding_key[input_index], output_blinding_key) == 1);
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_verify(CTX, &proof_a, ephemeral_input_tags, n_inputs, &ephemeral_output_tag) == 1);
+
+    /* Regenerate the unused ephemeral input tag with reblind instead of
+     * input_blinding_key[unused_index]. The modified tag is the only proof input
+     * that differs between the two rustsecp256k1zkp_v0_11_0_surjectionproof_generate calls. */
+    CHECK(rustsecp256k1zkp_v0_11_0_generator_generate_blinded(CTX, &ephemeral_input_tags[unused_index], fixed_input_tags[unused_index].data, reblind));
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_generate(CTX, &proof_b, ephemeral_input_tags, n_inputs, &ephemeral_output_tag, input_index, input_blinding_key[input_index], output_blinding_key) == 1);
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_verify(CTX, &proof_b, ephemeral_input_tags, n_inputs, &ephemeral_output_tag) == 1);
+
+    for (i = 0; i < n_used; i++) {
+        CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(&proof_a.data[32 + 32 * i], &proof_b.data[32 + 32 * i], 32) != 0);
+    }
+}
+
+DEFINE_SHA256_TRANSFORM_PROBE(sha256_surjection)
+static void test_surjectionproof_ctx_sha256(void) {
+    /* Check ctx-provided SHA256 compression override takes effect */
+    rustsecp256k1zkp_v0_11_0_context *ctx = rustsecp256k1zkp_v0_11_0_context_clone(CTX);
+    unsigned char serialized_default[SECP256K1_SURJECTIONPROOF_SERIALIZATION_BYTES(1, 1)];
+    unsigned char serialized_custom[SECP256K1_SURJECTIONPROOF_SERIALIZATION_BYTES(1, 1)];
+    unsigned char seed[32] = {1};
+    unsigned char input_blinding[32] = {1}, output_blinding[32] = {2};
+    rustsecp256k1zkp_v0_11_0_fixed_asset_tag fixed_tag = {{1}};
+    rustsecp256k1zkp_v0_11_0_generator input_tag, output_tag;
+    rustsecp256k1zkp_v0_11_0_surjectionproof proof;
+    size_t input_index;
+    size_t serialized_len = sizeof(serialized_default);
+
+    CHECK(rustsecp256k1zkp_v0_11_0_generator_generate_blinded(CTX, &input_tag, fixed_tag.data, input_blinding));
+    CHECK(rustsecp256k1zkp_v0_11_0_generator_generate_blinded(CTX, &output_tag, fixed_tag.data, output_blinding));
+
+    /* Default behavior. No ctx-provided SHA256 compression */
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_initialize(ctx, &proof, &input_index, &fixed_tag, 1, 1, &fixed_tag, 100, seed) > 0);
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_generate(ctx, &proof, &input_tag, 1, &output_tag, 0, input_blinding, output_blinding));
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_serialize(ctx, serialized_default, &serialized_len, &proof));
+    CHECK(!sha256_surjection_called);
+
+    /* Override SHA256 compression directly, bypassing the ctx setter sanity checks */
+    ctx->hash_ctx.fn_sha256_compression = sha256_surjection;
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_initialize(ctx, &proof, &input_index, &fixed_tag, 1, 1, &fixed_tag, 100, seed) > 0);
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_generate(ctx, &proof, &input_tag, 1, &output_tag, 0, input_blinding, output_blinding));
+    CHECK(rustsecp256k1zkp_v0_11_0_surjectionproof_serialize(ctx, serialized_custom, &serialized_len, &proof));
+    CHECK(sha256_surjection_called);
+    /* Outputs must differ if custom compression was used */
+    CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(serialized_default, serialized_custom, serialized_len) != 0);
+
+    rustsecp256k1zkp_v0_11_0_context_destroy(ctx);
+}
+
 /* --- Test registry --- */
 static const struct tf_test_entry tests_surjection[] = {
     CASE1(test_surjectionproof_api),
@@ -651,9 +827,12 @@ static const struct tf_test_entry tests_surjection[] = {
     CASE1(test_input_selection_all),
     CASE1(test_input_selection_distribution),
     CASE1(test_gen_verify_all),
+    CASE1(test_surjection_genrand),
+    CASE1(test_surjectionproof_generate_changes_s_values),
     CASE1(test_no_used_inputs_verify),
     CASE1(test_bad_serialize),
     CASE1(test_bad_parse),
+    CASE1(test_surjectionproof_ctx_sha256),
 };
 
 #endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/whitelist/main_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/whitelist/main_impl.h
@@ -133,19 +133,28 @@ size_t rustsecp256k1zkp_v0_11_0_whitelist_signature_n_keys(const rustsecp256k1zk
 }
 
 int rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(const rustsecp256k1zkp_v0_11_0_context* ctx, rustsecp256k1zkp_v0_11_0_whitelist_signature *sig, const unsigned char *input, size_t input_len) {
+    size_t n_keys;
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(sig != NULL);
     ARG_CHECK(input != NULL);
+
+    /* The header guarantees sig is initialized on every path and that a failed
+     * parse fails validation for any key set. MAX_KEYS + 1 is that canonical
+     * invalid state: _verify rejects it on sig->n_keys > MAX_KEYS regardless of
+     * the count the caller supplies. */
+    memset(sig, 0, sizeof(*sig));
+    sig->n_keys = MAX_KEYS + 1;
 
     if (input_len == 0) {
         return 0;
     }
 
-    sig->n_keys = input[0];
-    if (sig->n_keys > MAX_KEYS || input_len != 1 + 32 * (sig->n_keys + 1)) {
+    n_keys = input[0];
+    if (n_keys > MAX_KEYS || input_len != 1 + 32 * (n_keys + 1)) {
         return 0;
     }
-    memcpy(&sig->data[0], &input[1], 32 * (sig->n_keys + 1));
+    sig->n_keys = n_keys;
+    memcpy(&sig->data[0], &input[1], 32 * (n_keys + 1));
 
     return 1;
 }
@@ -156,6 +165,10 @@ int rustsecp256k1zkp_v0_11_0_whitelist_signature_serialize(const rustsecp256k1zk
     ARG_CHECK(output_len != NULL);
     ARG_CHECK(sig != NULL);
 
+    /* Do not trust n_keys to have come from _parse. */
+    if (sig->n_keys > MAX_KEYS) {
+        return 0;
+    }
     if (*output_len < 1 + 32 * (sig->n_keys + 1)) {
         return 0;
     }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/whitelist/tests_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/whitelist/tests_impl.h
@@ -23,12 +23,17 @@ static void test_whitelist_end_to_end_internal(const unsigned char *summed_secke
         /* Serialization round trip */
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_serialize(CTX, serialized, &slen, &sig) == 1);
         CHECK(slen == 33 + 32 * n_keys);
-        CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(CTX, &sig1, serialized, slen) == 1);
         /* (Check various bad-length conditions) */
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(CTX, &sig1, serialized, slen + 32) == 0);
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(CTX, &sig1, serialized, slen + 1) == 0);
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(CTX, &sig1, serialized, slen - 1) == 0);
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(CTX, &sig1, serialized, 0) == 0);
+        /* A failed parse must leave a signature that fails validation for any
+         * key set, as documented on rustsecp256k1zkp_v0_11_0_whitelist_signature_parse. */
+        CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_n_keys(&sig1) > SECP256K1_WHITELIST_MAX_N_KEYS);
+        CHECK(rustsecp256k1zkp_v0_11_0_whitelist_verify(CTX, &sig1, online_pubkeys, offline_pubkeys, n_keys, sub_pubkey) == 0);
+        /* Re-parse to restore a valid state. */
+        CHECK(rustsecp256k1zkp_v0_11_0_whitelist_signature_parse(CTX, &sig1, serialized, slen) == 1);
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_verify(CTX, &sig1, online_pubkeys, offline_pubkeys, n_keys, sub_pubkey) == 1);
         CHECK(rustsecp256k1zkp_v0_11_0_whitelist_verify(CTX, &sig1, offline_pubkeys, online_pubkeys, n_keys, sub_pubkey) != 1);
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/modules/whitelist/whitelist_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/modules/whitelist/whitelist_impl.h
@@ -61,8 +61,9 @@ static int rustsecp256k1zkp_v0_11_0_whitelist_compute_tweaked_privkey(const rust
     }
     if (ret) {
         rustsecp256k1zkp_v0_11_0_gej pkeyj;
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &pkeyj, skey);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&ctx->ecmult_gen_ctx, &pkeyj, skey);
         ret = rustsecp256k1zkp_v0_11_0_whitelist_hash_pubkey(hash_ctx, &tweak, &pkeyj);
+        rustsecp256k1zkp_v0_11_0_gej_clear(&pkeyj);
     }
     if (ret) {
         rustsecp256k1zkp_v0_11_0_scalar sonline;
@@ -116,6 +117,9 @@ static int rustsecp256k1zkp_v0_11_0_whitelist_compute_keys_and_message(const rus
         /* compute tweaked keys */
         rustsecp256k1zkp_v0_11_0_gej_set_ge(&tweaked_gej, &offline_ge);
         rustsecp256k1zkp_v0_11_0_gej_add_ge_var(&tweaked_gej, &tweaked_gej, &subkey_ge, NULL);
+        /* Fails only for the degenerate destination W = -P_i, where the ring
+         * key intentionally collapses to Q_i. See the rationale on
+         * rustsecp256k1zkp_v0_11_0_whitelist_verify in include/rustsecp256k1zkp_v0_11_0_whitelist.h. */
         rustsecp256k1zkp_v0_11_0_whitelist_tweak_pubkey(hash_ctx, &tweaked_gej);
         rustsecp256k1zkp_v0_11_0_gej_add_ge_var(&keys[i], &tweaked_gej, &online_ge, NULL);
     }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/scalar.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/scalar.h
@@ -22,10 +22,10 @@
 /** Clear a scalar to prevent the leak of sensitive data. */
 static void rustsecp256k1zkp_v0_11_0_scalar_clear(rustsecp256k1zkp_v0_11_0_scalar *r);
 
-/** Access bits (1 < count <= 32) from a scalar. All requested bits must belong to the same 32-bit limb. */
+/** Access bits (1 <= count <= 32) from a scalar. All requested bits must belong to the same 32-bit limb. */
 static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count);
 
-/** Access bits (1 < count <= 32) from a scalar. offset + count must be < 256. Not constant time in offset and count. */
+/** Access bits (1 <= count <= 32) from a scalar. offset + count must be <= 256. Not constant time in offset and count. */
 static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_var(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count);
 
 /** Set a scalar from a big endian byte array. The scalar will be reduced modulo group order `n`.

--- a/secp256k1-zkp-sys/depend/secp256k1/src/scalar_4x64_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/scalar_4x64_impl.h
@@ -51,7 +51,8 @@ SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_scalar_set_u64(rustsecp256
 SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count) {
     SECP256K1_SCALAR_VERIFY(a);
     VERIFY_CHECK(count > 0 && count <= 32);
-    VERIFY_CHECK((offset + count - 1) >> 6 == offset >> 6);
+    VERIFY_CHECK(offset <= 256 - count);
+    VERIFY_CHECK((offset + count - 1) >> 5 == offset >> 5);
 
     return (a->d[offset >> 6] >> (offset & 0x3F)) & (0xFFFFFFFF >> (32 - count));
 }
@@ -59,12 +60,13 @@ SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32
 SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_var(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count) {
     SECP256K1_SCALAR_VERIFY(a);
     VERIFY_CHECK(count > 0 && count <= 32);
-    VERIFY_CHECK(offset + count <= 256);
+    VERIFY_CHECK(offset <= 256 - count);
 
     if ((offset + count - 1) >> 6 == offset >> 6) {
-        return rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(a, offset, count);
+        return (a->d[offset >> 6] >> (offset & 0x3F)) & (0xFFFFFFFF >> (32 - count));
     } else {
         VERIFY_CHECK((offset >> 6) + 1 < 4);
+        VERIFY_CHECK((offset & 0x3F) > 0);
         return ((a->d[offset >> 6] >> (offset & 0x3F)) | (a->d[(offset >> 6) + 1] << (64 - (offset & 0x3F)))) & (0xFFFFFFFF >> (32 - count));
     }
 }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/scalar_8x32_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/scalar_8x32_impl.h
@@ -69,6 +69,7 @@ SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_scalar_set_u64(rustsecp256
 SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count) {
     SECP256K1_SCALAR_VERIFY(a);
     VERIFY_CHECK(count > 0 && count <= 32);
+    VERIFY_CHECK(offset <= 256 - count);
     VERIFY_CHECK((offset + count - 1) >> 5 == offset >> 5);
 
     return (a->d[offset >> 5] >> (offset & 0x1F)) & (0xFFFFFFFF >> (32 - count));
@@ -77,7 +78,7 @@ SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32
 SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_var(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count) {
     SECP256K1_SCALAR_VERIFY(a);
     VERIFY_CHECK(count > 0 && count <= 32);
-    VERIFY_CHECK(offset + count <= 256);
+    VERIFY_CHECK(offset <= 256 - count);
 
     if ((offset + count - 1) >> 5 == offset >> 5) {
         return rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(a, offset, count);

--- a/secp256k1-zkp-sys/depend/secp256k1/src/scalar_low_impl.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/scalar_low_impl.h
@@ -33,8 +33,10 @@ SECP256K1_INLINE static void rustsecp256k1zkp_v0_11_0_scalar_set_u64(rustsecp256
 
 SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count) {
     SECP256K1_SCALAR_VERIFY(a);
-
     VERIFY_CHECK(count > 0 && count <= 32);
+    VERIFY_CHECK(offset <= 256 - count);
+    VERIFY_CHECK((offset + count - 1) >> 5 == offset >> 5);
+
     if (offset < 32) {
         return (*a >> offset) & (0xFFFFFFFF >> (32 - count));
     } else {
@@ -44,8 +46,14 @@ SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32
 
 SECP256K1_INLINE static uint32_t rustsecp256k1zkp_v0_11_0_scalar_get_bits_var(const rustsecp256k1zkp_v0_11_0_scalar *a, unsigned int offset, unsigned int count) {
     SECP256K1_SCALAR_VERIFY(a);
+    VERIFY_CHECK(count > 0 && count <= 32);
+    VERIFY_CHECK(offset <= 256 - count);
 
-    return rustsecp256k1zkp_v0_11_0_scalar_get_bits_limb32(a, offset, count);
+    if (offset < 32) {
+        return (*a >> offset) & (0xFFFFFFFF >> (32 - count));
+    } else {
+        return 0;
+    }
 }
 
 SECP256K1_INLINE static int rustsecp256k1zkp_v0_11_0_scalar_check_overflow(const rustsecp256k1zkp_v0_11_0_scalar *a) { return *a >= EXHAUSTIVE_TEST_ORDER; }

--- a/secp256k1-zkp-sys/depend/secp256k1/src/secp256k1.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/secp256k1.c
@@ -564,12 +564,10 @@ static int rustsecp256k1zkp_v0_11_0_ecdsa_sign_inner(const rustsecp256k1zkp_v0_1
         rustsecp256k1zkp_v0_11_0_declassify(ctx, &is_nonce_valid, sizeof(is_nonce_valid));
         if (is_nonce_valid) {
             if (s2c_data32 != NULL) {
-                rustsecp256k1zkp_v0_11_0_gej nonce_pj;
                 rustsecp256k1zkp_v0_11_0_ge nonce_p;
 
                 /* Compute original nonce commitment/pubkey */
-                rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &nonce_pj, &non);
-                rustsecp256k1zkp_v0_11_0_ge_set_gej(&nonce_p, &nonce_pj);
+                rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &nonce_p, &non);
                 if (s2c_opening != NULL) {
                     rustsecp256k1zkp_v0_11_0_ecdsa_s2c_opening_save(s2c_opening, &nonce_p);
                 }
@@ -639,15 +637,12 @@ int rustsecp256k1zkp_v0_11_0_ec_seckey_verify(const rustsecp256k1zkp_v0_11_0_con
 }
 
 static int rustsecp256k1zkp_v0_11_0_ec_pubkey_create_helper(const rustsecp256k1zkp_v0_11_0_ecmult_gen_context *ecmult_gen_ctx, rustsecp256k1zkp_v0_11_0_scalar *seckey_scalar, rustsecp256k1zkp_v0_11_0_ge *p, const unsigned char *seckey) {
-    rustsecp256k1zkp_v0_11_0_gej pj;
     int ret;
 
     ret = rustsecp256k1zkp_v0_11_0_scalar_set_b32_seckey(seckey_scalar, seckey);
     rustsecp256k1zkp_v0_11_0_scalar_cmov(seckey_scalar, &rustsecp256k1zkp_v0_11_0_scalar_one, !ret);
 
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(ecmult_gen_ctx, &pj, seckey_scalar);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(p, &pj);
-    rustsecp256k1zkp_v0_11_0_gej_clear(&pj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(ecmult_gen_ctx, p, seckey_scalar);
     return ret;
 }
 

--- a/secp256k1-zkp-sys/depend/secp256k1/src/tests.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/tests.c
@@ -37,6 +37,11 @@
 #include "int128_impl.h"
 #endif
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 #define CONDITIONAL_TEST(cnt, nam) if (COUNT < (cnt)) { printf("Skipping %s (iteration count too low)\n", nam); } else
 
 static rustsecp256k1zkp_v0_11_0_context *CTX = NULL;
@@ -287,7 +292,6 @@ static void run_proper_context_tests(int use_prealloc) {
     void *my_ctx_prealloc = NULL;
     unsigned char seed[32] = {0x17};
 
-    rustsecp256k1zkp_v0_11_0_gej pubj;
     rustsecp256k1zkp_v0_11_0_ge pub;
     rustsecp256k1zkp_v0_11_0_scalar msg, key, nonce;
     rustsecp256k1zkp_v0_11_0_scalar sigr, sigs;
@@ -375,8 +379,7 @@ static void run_proper_context_tests(int use_prealloc) {
     /*** attempt to use them ***/
     testutil_random_scalar_order_test(&msg);
     testutil_random_scalar_order_test(&key);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&my_ctx->ecmult_gen_ctx, &pubj, &key);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&pub, &pubj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&my_ctx->ecmult_gen_ctx, &pub, &key);
 
     /* obtain a working nonce */
     do {
@@ -415,7 +418,6 @@ static void run_scratch_tests(void) {
     size_t checkpoint;
     size_t checkpoint_2;
     rustsecp256k1zkp_v0_11_0_scratch_space *scratch;
-    rustsecp256k1zkp_v0_11_0_scratch_space local_scratch;
 
     /* Test public API */
     scratch = rustsecp256k1zkp_v0_11_0_scratch_space_create(CTX, 1000);
@@ -455,16 +457,7 @@ static void run_scratch_tests(void) {
     CHECK_ERROR_VOID(CTX, rustsecp256k1zkp_v0_11_0_scratch_apply_checkpoint(&CTX->error_callback, scratch, checkpoint_2)); /* checkpoint_2 is after checkpoint */
     CHECK_ERROR_VOID(CTX, rustsecp256k1zkp_v0_11_0_scratch_apply_checkpoint(&CTX->error_callback, scratch, (size_t) -1)); /* this is just wildly invalid */
 
-    /* try to use badly initialized scratch space */
-    rustsecp256k1zkp_v0_11_0_scratch_space_destroy(CTX, scratch);
-    memset(&local_scratch, 0, sizeof(local_scratch));
-    scratch = &local_scratch;
-    CHECK_ERROR(CTX, rustsecp256k1zkp_v0_11_0_scratch_max_allocation(&CTX->error_callback, scratch, 0));
-    CHECK_ERROR(CTX, rustsecp256k1zkp_v0_11_0_scratch_alloc(&CTX->error_callback, scratch, 500));
-    CHECK_ERROR_VOID(CTX, rustsecp256k1zkp_v0_11_0_scratch_space_destroy(CTX, scratch));
-
     /* Test that large integers do not wrap around in a bad way */
-    scratch = rustsecp256k1zkp_v0_11_0_scratch_space_create(CTX, 1000);
     /* Try max allocation with a large number of objects. Only makes sense if
      * ALIGNMENT is greater than 1 because otherwise the objects take no extra
      * space. */
@@ -477,6 +470,21 @@ static void run_scratch_tests(void) {
 
     /* cleanup */
     rustsecp256k1zkp_v0_11_0_scratch_space_destroy(CTX, NULL); /* no-op */
+}
+
+/* try to use badly initialized scratch space */
+static void run_invalid_scratch_space_tests(void) {
+    rustsecp256k1zkp_v0_11_0_scratch_space* scratch = checked_malloc(&CTX->error_callback, sizeof(*scratch));
+    size_t magic_size = sizeof(scratch->magic);
+    memset(scratch, 0, sizeof(*scratch));
+    /* catch accesses beyond the magic */
+    SECP256K1_CHECKMEM_UNDEFINE((unsigned char*)scratch + magic_size, sizeof(*scratch) - magic_size);
+
+    CHECK_ERROR(CTX, rustsecp256k1zkp_v0_11_0_scratch_max_allocation(&CTX->error_callback, scratch, 0));
+    CHECK_ERROR(CTX, rustsecp256k1zkp_v0_11_0_scratch_alloc(&CTX->error_callback, scratch, 500));
+    CHECK_ERROR_VOID(CTX, rustsecp256k1zkp_v0_11_0_scratch_space_destroy(CTX, scratch));
+
+    free(scratch);
 }
 
 /* A compression function that does nothing */
@@ -3112,6 +3120,18 @@ static int fe_equal(const rustsecp256k1zkp_v0_11_0_fe *a, const rustsecp256k1zkp
     return rustsecp256k1zkp_v0_11_0_fe_equal(&an, &bn);
 }
 
+static void run_fe_equal_magnitude_boundaries(void) {
+    int i;
+    rustsecp256k1zkp_v0_11_0_fe a, b;
+    for (i = 0; i < 100 * COUNT; ++i) {
+        testutil_random_fe(&a);
+        b = a;
+        testutil_random_fe_magnitude(&a, 1);
+        testutil_random_fe_magnitude(&b, 30);
+        CHECK(rustsecp256k1zkp_v0_11_0_fe_equal(&a, &b));
+    }
+}
+
 static void run_field_convert(void) {
     static const unsigned char b32[32] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -4360,19 +4380,16 @@ static void test_ec_combine(void) {
     const rustsecp256k1zkp_v0_11_0_pubkey* d[6];
     rustsecp256k1zkp_v0_11_0_pubkey sd;
     rustsecp256k1zkp_v0_11_0_pubkey sd2;
-    rustsecp256k1zkp_v0_11_0_gej Qj;
     rustsecp256k1zkp_v0_11_0_ge Q;
     int i;
     for (i = 1; i <= 6; i++) {
         rustsecp256k1zkp_v0_11_0_scalar s;
         testutil_random_scalar_order_test(&s);
         rustsecp256k1zkp_v0_11_0_scalar_add(&sum, &sum, &s);
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &Qj, &s);
-        rustsecp256k1zkp_v0_11_0_ge_set_gej(&Q, &Qj);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &Q, &s);
         rustsecp256k1zkp_v0_11_0_pubkey_save(&data[i - 1], &Q);
         d[i - 1] = &data[i - 1];
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &Qj, &sum);
-        rustsecp256k1zkp_v0_11_0_ge_set_gej(&Q, &Qj);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &Q, &sum);
         rustsecp256k1zkp_v0_11_0_pubkey_save(&sd, &Q);
         CHECK(rustsecp256k1zkp_v0_11_0_ec_pubkey_combine(CTX, &sd2, d, i) == 1);
         CHECK(rustsecp256k1zkp_v0_11_0_memcmp_var(&sd, &sd2, sizeof(sd)) == 0);
@@ -4397,8 +4414,7 @@ static void test_ec_commit(void) {
 
     /* Create random keypair and data */
     testutil_random_scalar_order_test(&seckey_s);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pubkeyj, &seckey_s);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&pubkey, &pubkeyj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &pubkey, &seckey_s);
     testrand256_test(data);
 
     /* Commit to data and verify */
@@ -4408,7 +4424,7 @@ static void test_ec_commit(void) {
     CHECK(rustsecp256k1zkp_v0_11_0_ec_commit_verify(hash_ctx, &commitment, &pubkey, &sha, data, 32) == 1);
     rustsecp256k1zkp_v0_11_0_sha256_initialize(&sha);
     CHECK(rustsecp256k1zkp_v0_11_0_ec_commit_seckey(hash_ctx, &seckey_s, &pubkey, &sha, data, 32) == 1);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pubkeyj, &seckey_s);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &pubkeyj, &seckey_s);
     rustsecp256k1zkp_v0_11_0_gej_eq_ge_var(&pubkeyj, &commitment);
 
     /* Check that verification fails with different data */
@@ -4430,7 +4446,6 @@ static void test_ec_commit_api(void) {
     unsigned char seckey[32];
     rustsecp256k1zkp_v0_11_0_scalar seckey_s;
     rustsecp256k1zkp_v0_11_0_ge pubkey;
-    rustsecp256k1zkp_v0_11_0_gej pubkeyj;
     rustsecp256k1zkp_v0_11_0_ge commitment;
     unsigned char data[32];
     rustsecp256k1zkp_v0_11_0_sha256 sha;
@@ -4440,8 +4455,7 @@ static void test_ec_commit_api(void) {
     /* Create random keypair */
     testutil_random_scalar_order_test(&seckey_s);
     rustsecp256k1zkp_v0_11_0_scalar_get_b32(seckey, &seckey_s);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pubkeyj, &seckey_s);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&pubkey, &pubkeyj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &pubkey, &seckey_s);
 
     rustsecp256k1zkp_v0_11_0_sha256_initialize(&sha);
     CHECK(rustsecp256k1zkp_v0_11_0_ec_commit(hash_ctx, &commitment, &pubkey, &sha, data, 1) == 1);
@@ -4757,9 +4771,9 @@ static void test_ecmult_target(const rustsecp256k1zkp_v0_11_0_scalar* target, in
 
     /* EC multiplications */
     if (mode == 0) {
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &p1j, &n1);
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &p2j, &n2);
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &ptj, target);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &p1j, &n1);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &p2j, &n2);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &ptj, target);
     } else if (mode == 1) {
         rustsecp256k1zkp_v0_11_0_ecmult(&p1j, &pj, &n1, &rustsecp256k1zkp_v0_11_0_scalar_zero);
         rustsecp256k1zkp_v0_11_0_ecmult(&p2j, &pj, &n2, &rustsecp256k1zkp_v0_11_0_scalar_zero);
@@ -5326,7 +5340,7 @@ static int test_ecmult_multi_random(rustsecp256k1zkp_v0_11_0_scratch *scratch) {
             rustsecp256k1zkp_v0_11_0_scalar_mul(&scalars[filled], &sc_tmp, &g_scalar);
             rustsecp256k1zkp_v0_11_0_scalar_inverse_var(&sc_tmp, &sc_tmp);
             rustsecp256k1zkp_v0_11_0_scalar_negate(&sc_tmp, &sc_tmp);
-            rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &gejs[filled], &sc_tmp);
+            rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &gejs[filled], &sc_tmp);
             ++filled;
             ++mults;
         }
@@ -5806,7 +5820,7 @@ static void test_ecmult_accumulate(rustsecp256k1zkp_v0_11_0_sha256* acc, const r
     size_t i;
     rustsecp256k1zkp_v0_11_0_gej_set_ge(&gj, &rustsecp256k1zkp_v0_11_0_ge_const_g);
     rustsecp256k1zkp_v0_11_0_gej_set_infinity(&infj);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &rj[0], x);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &rj[0], x);
     rustsecp256k1zkp_v0_11_0_ecmult(&rj[1], &gj, x, NULL);
     rustsecp256k1zkp_v0_11_0_ecmult(&rj[2], &gj, x, &rustsecp256k1zkp_v0_11_0_scalar_zero);
     rustsecp256k1zkp_v0_11_0_ecmult(&rj[3], &infj, &rustsecp256k1zkp_v0_11_0_scalar_zero, x);
@@ -5950,6 +5964,25 @@ static void run_ecmult_constants(void) {
     }
 }
 
+static void run_ecmult_gen_ge(void) {
+    /* Test that rustsecp256k1zkp_v0_11_0_ecmult_gen_ge result matches rustsecp256k1zkp_v0_11_0_ecmult_gen_gej with
+     * manual Jacobian-to-affine conversion (rustsecp256k1zkp_v0_11_0_ge_set_gej) over random scalars */
+    int i;
+
+    for (i = 0; i < COUNT; i++) {
+        rustsecp256k1zkp_v0_11_0_scalar scalar;
+        rustsecp256k1zkp_v0_11_0_gej result_gej;
+        rustsecp256k1zkp_v0_11_0_ge result_ge, expected_ge;
+
+        testutil_random_scalar_order_test(&scalar);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &result_gej, &scalar);
+        rustsecp256k1zkp_v0_11_0_ge_set_gej(&expected_ge, &result_gej);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &result_ge, &scalar);
+
+        CHECK(rustsecp256k1zkp_v0_11_0_ge_eq_var(&result_ge, &expected_ge));
+    }
+}
+
 static void test_ecmult_gen_blind(void) {
     /* Test ecmult_gen() blinding and confirm that the blinding changes, the affine points match, and the z's don't match. */
     rustsecp256k1zkp_v0_11_0_scalar key;
@@ -5960,13 +5993,13 @@ static void test_ecmult_gen_blind(void) {
     rustsecp256k1zkp_v0_11_0_ge p;
     rustsecp256k1zkp_v0_11_0_ge pge;
     testutil_random_scalar_order_test(&key);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pgej, &key);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &pgej, &key);
     testrand256(seed32);
     b = CTX->ecmult_gen_ctx.scalar_offset;
     p = CTX->ecmult_gen_ctx.ge_offset;
     rustsecp256k1zkp_v0_11_0_ecmult_gen_blind(&CTX->ecmult_gen_ctx, rustsecp256k1zkp_v0_11_0_get_hash_context(CTX), seed32);
     CHECK(!rustsecp256k1zkp_v0_11_0_scalar_eq(&b, &CTX->ecmult_gen_ctx.scalar_offset));
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pgej2, &key);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &pgej2, &key);
     CHECK(!gej_xyz_equals_gej(&pgej, &pgej2));
     CHECK(!rustsecp256k1zkp_v0_11_0_ge_eq_var(&p, &CTX->ecmult_gen_ctx.ge_offset));
     rustsecp256k1zkp_v0_11_0_ge_set_gej(&pge, &pgej);
@@ -5996,7 +6029,7 @@ static void test_ecmult_gen_edge_cases(void) {
 
     for (i = -1; i < 2; ++i) {
         /* Run test with gn = i - scalar_offset (so that the ecmult_gen recoded value represents i). */
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &res1, &gn);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_gej(&CTX->ecmult_gen_ctx, &res1, &gn);
         rustsecp256k1zkp_v0_11_0_ecmult(&res2, NULL, &rustsecp256k1zkp_v0_11_0_scalar_zero, &gn);
         rustsecp256k1zkp_v0_11_0_ecmult_const(&res3, &rustsecp256k1zkp_v0_11_0_ge_const_g, &gn);
         CHECK(rustsecp256k1zkp_v0_11_0_gej_eq_var(&res1, &res2));
@@ -6679,7 +6712,6 @@ static void random_sign(rustsecp256k1zkp_v0_11_0_scalar *sigr, rustsecp256k1zkp_
 }
 
 static void test_ecdsa_sign_verify(void) {
-    rustsecp256k1zkp_v0_11_0_gej pubj;
     rustsecp256k1zkp_v0_11_0_ge pub;
     rustsecp256k1zkp_v0_11_0_scalar one;
     rustsecp256k1zkp_v0_11_0_scalar msg, key;
@@ -6688,8 +6720,7 @@ static void test_ecdsa_sign_verify(void) {
     int recid;
     testutil_random_scalar_order_test(&msg);
     testutil_random_scalar_order_test(&key);
-    rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &pubj, &key);
-    rustsecp256k1zkp_v0_11_0_ge_set_gej(&pub, &pubj);
+    rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &pub, &key);
     getrec = testrand_bits(1);
     /* The specific way in which this conditional is written sidesteps a potential bug in clang.
        See the commit messages of the commit that introduced this comment for details. */
@@ -7448,7 +7479,6 @@ static void run_ecdsa_edge_cases(void) {
 
     /* Test the case where ECDSA recomputes a point that is infinity. */
     {
-        rustsecp256k1zkp_v0_11_0_gej keyj;
         rustsecp256k1zkp_v0_11_0_ge key;
         rustsecp256k1zkp_v0_11_0_scalar msg;
         rustsecp256k1zkp_v0_11_0_scalar sr, ss;
@@ -7456,8 +7486,7 @@ static void run_ecdsa_edge_cases(void) {
         rustsecp256k1zkp_v0_11_0_scalar_negate(&ss, &ss);
         rustsecp256k1zkp_v0_11_0_scalar_inverse(&ss, &ss);
         rustsecp256k1zkp_v0_11_0_scalar_set_int(&sr, 1);
-        rustsecp256k1zkp_v0_11_0_ecmult_gen(&CTX->ecmult_gen_ctx, &keyj, &sr);
-        rustsecp256k1zkp_v0_11_0_ge_set_gej(&key, &keyj);
+        rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&CTX->ecmult_gen_ctx, &key, &sr);
         msg = ss;
         CHECK(rustsecp256k1zkp_v0_11_0_ecdsa_sig_verify(&sr, &ss, &key, &msg) == 0);
     }
@@ -8116,6 +8145,7 @@ static const struct tf_test_entry tests_general[] = {
     CASE(all_static_context_tests),
     CASE(deprecated_context_flags_test),
     CASE(scratch_tests),
+    CASE(invalid_scratch_space_tests),
     CASE(plug_sha256_compression_tests),
     CASE(sha256_multi_block_compression_tests),
 };
@@ -8145,6 +8175,7 @@ static const struct tf_test_entry tests_scalar[] = {
 static const struct tf_test_entry tests_field[] = {
     CASE(field_half),
     CASE(field_misc),
+    CASE(fe_equal_magnitude_boundaries),
     CASE(field_convert),
     CASE(field_be32_overflow),
     CASE(fe_mul),
@@ -8165,6 +8196,7 @@ static const struct tf_test_entry tests_ecmult[] = {
     CASE(ecmult_near_split_bound),
     CASE(ecmult_chain),
     CASE(ecmult_constants),
+    CASE(ecmult_gen_ge),
     CASE(ecmult_gen_blind),
     CASE(ecmult_const_tests),
     CASE(ecmult_multi_tests),
@@ -8176,6 +8208,7 @@ static const struct tf_test_entry tests_ec[] = {
     CASE(ec_pubkey_parse_test),
     CASE(eckey_edge_case_test),
     CASE(eckey_negate_test),
+    CASE(ec_commit),
 };
 
 static const struct tf_test_entry tests_ecdsa[] = {
@@ -8197,6 +8230,7 @@ static const struct tf_test_entry tests_utils[] = {
     CASE(rustsecp256k1zkp_v0_11_0_is_zero_array_test),
     CASE(rustsecp256k1zkp_v0_11_0_byteorder_tests),
     CASE(cmov_tests),
+    CASE(util_tests),
 };
 
 /* Register test modules */
@@ -8301,3 +8335,7 @@ int main(int argc, char **argv) {
     if (tf_init(&tf, argc, argv) != 0) return EXIT_FAILURE;
     return tf_run(&tf);
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/tests_exhaustive.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/tests_exhaustive.c
@@ -31,6 +31,11 @@
 #include "testutil.h"
 #include "util.h"
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 static int count = 2;
 
 static uint32_t num_cores = 1;
@@ -337,6 +342,10 @@ static void test_exhaustive_sign(const rustsecp256k1zkp_v0_11_0_context *ctx, co
      */
 }
 
+#ifdef ENABLE_MODULE_ECDH
+#include "modules/ecdh/tests_exhaustive_impl.h"
+#endif
+
 #ifdef ENABLE_MODULE_RECOVERY
 #include "modules/recovery/tests_exhaustive_impl.h"
 #endif
@@ -417,12 +426,10 @@ int main(int argc, char** argv) {
             /* Verify against ecmult_gen */
             {
                 rustsecp256k1zkp_v0_11_0_scalar scalar_i;
-                rustsecp256k1zkp_v0_11_0_gej generatedj;
                 rustsecp256k1zkp_v0_11_0_ge generated;
 
                 rustsecp256k1zkp_v0_11_0_scalar_set_int(&scalar_i, i);
-                rustsecp256k1zkp_v0_11_0_ecmult_gen(&ctx->ecmult_gen_ctx, &generatedj, &scalar_i);
-                rustsecp256k1zkp_v0_11_0_ge_set_gej(&generated, &generatedj);
+                rustsecp256k1zkp_v0_11_0_ecmult_gen_ge(&ctx->ecmult_gen_ctx, &generated, &scalar_i);
 
                 CHECK(!rustsecp256k1zkp_v0_11_0_ge_is_infinity(&group[i]));
                 CHECK(rustsecp256k1zkp_v0_11_0_ge_eq_var(&group[i], &generated));
@@ -437,6 +444,9 @@ int main(int argc, char** argv) {
         test_exhaustive_sign(ctx, group);
         test_exhaustive_verify(ctx, group);
 
+#ifdef ENABLE_MODULE_ECDH
+        test_exhaustive_ecdh(ctx, group);
+#endif
 #ifdef ENABLE_MODULE_RECOVERY
         test_exhaustive_recovery(ctx, group);
 #endif
@@ -462,3 +472,7 @@ int main(int argc, char** argv) {
     printf("no problems found\n");
     return EXIT_SUCCESS;
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/unit_test.c
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/unit_test.c
@@ -17,6 +17,11 @@
 #include "testrand.h"
 #include "tests_common.h"
 
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic warning "-Wunused-function"
+#endif
+
 #define UNUSED(x) (void)(x)
 
 /* Number of times certain tests will run */
@@ -477,3 +482,7 @@ static int tf_run(struct tf_framework* tf) {
 
     return status;
 }
+
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif

--- a/secp256k1-zkp-sys/depend/secp256k1/src/util.h
+++ b/secp256k1-zkp-sys/depend/secp256k1/src/util.h
@@ -37,6 +37,17 @@
 #  define SECP256K1_INLINE inline
 # endif
 
+# if !defined(_DEBUG) && !defined(__NO_INLINE__) && !defined(__OPTIMIZE_SIZE__)
+#  if defined(__OPTIMIZE__) && (SECP256K1_GNUC_PREREQ(3, 0) || defined(__clang__))
+#   define SECP256K1_FORCE_INLINE SECP256K1_INLINE __attribute__((always_inline))
+#  elif defined(_MSC_VER)
+#   define SECP256K1_FORCE_INLINE __forceinline
+#  endif
+# endif
+# ifndef SECP256K1_FORCE_INLINE
+#  define SECP256K1_FORCE_INLINE SECP256K1_INLINE
+# endif
+
 /** Assert statically that expr is true.
  *
  * This is a statement-like macro and can only be used inside functions.

--- a/secp256k1-zkp-sys/vendor-libsecp.sh
+++ b/secp256k1-zkp-sys/vendor-libsecp.sh
@@ -8,7 +8,7 @@ else
     SECP_VENDOR_GIT_ROOT="$(realpath "$SECP_VENDOR_GIT_ROOT")"
 fi
 SECP_SYS="$SECP_VENDOR_GIT_ROOT"/secp256k1-zkp-sys
-DEFAULT_VERSION_CODE=$(grep version "$SECP_SYS/Cargo.toml" | sed 's/\./_/g' | sed 's/.*"\(.*\)".*/\1/')
+DEFAULT_VERSION_CODE=$(grep '^version = ' "$SECP_SYS/Cargo.toml" | sed 's/\./_/g' | sed 's/.*"\(.*\)".*/\1/')
 DEFAULT_DEPEND_DIR="$SECP_SYS/depend"
 DEFAULT_SECP_REPO=https://github.com/BlockstreamResearch/secp256k1-zkp.git
 


### PR DESCRIPTION
Re-vendors the C library to [10366db](https://github.com/BlockstreamResearch/secp256k1-zkp/commit/10366dbbbfeb11457f2aae3b23e154ab7d6a1fe4) to pick up the recently merged security fixes in secp256k1-zkp:
- surjection proof nonce binding ([#369](https://github.com/BlockstreamResearch/secp256k1-zkp/pull/369))
- rangeproof nonce documentation ([#370](https://github.com/BlockstreamResearch/secp256k1-zkp/pull/370))
- whitelist/bppp defensive hardening + docs ([#371](https://github.com/BlockstreamResearch/secp256k1-zkp/pull/371))
- missing clears on secret values ([#367](https://github.com/BlockstreamResearch/secp256k1-zkp/pull/367))

Since the previous vendored rev was from June, this also brings the July upstream libsecp sync ([#366](https://github.com/BlockstreamResearch/secp256k1-zkp/pull/366)) and hash-context test ports ([#365](https://github.com/BlockstreamResearch/secp256k1-zkp/pull/365)) along. All changes are internal (refactors, tests, benches, docs).

Also fixes vendor-libsecp.sh: its grep version matched the rust-version line added to Cargo.toml, producing a two-line version code that broke symbol renaming (unterminated 's' command). Anchored to ^version = .